### PR TITLE
[DoctrineORMMapper] added Discriminator, Discriminator Column, and Inheritance Type.

### DIFF
--- a/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
+++ b/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
@@ -40,6 +40,20 @@ class AddMapperInformationCompilerPass implements CompilerPassInterface
             }
         }
 
+        foreach (DoctrineCollector::getInstance()->getDiscriminatorColumns() as $class => $columnDefinition) {
+                $mapper->addMethodCall('addDiscriminatorColumn', array($class, $columnDefinition));
+        }
+
+        foreach (DoctrineCollector::getInstance()->getDiscriminators() as $class => $discriminators) {
+            foreach ($discriminators as $key => $discriminatorClass) {
+                $mapper->addMethodCall('addDiscriminator', array($class, $key, $discriminatorClass));
+            }
+        }
+
+        foreach (DoctrineCollector::getInstance()->getInheritanceTypes() as $class => $type) {
+            $mapper->addMethodCall('addInheritanceType', array($class, $type));
+        }
+
         foreach (DoctrineCollector::getInstance()->getIndexes() as $class => $indexes) {
             foreach ($indexes as $field => $options) {
                 $mapper->addMethodCall('addIndex', array($class, $field, $options));

--- a/Mapper/DoctrineCollector.php
+++ b/Mapper/DoctrineCollector.php
@@ -16,6 +16,12 @@ class DoctrineCollector
 
     protected $indexes;
 
+    protected $discriminators;
+
+    protected $discriminatorColumns;
+
+    protected $inheritanceTypes;
+
     private static $instance;
 
     public function __construct()
@@ -34,6 +40,54 @@ class DoctrineCollector
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Add a discriminator to a class.
+     *
+     * @param  string  $class               The Class
+     * @param  string  $key                 Key is the database value and values are the classes
+     * @param  string  $discriminatorClass  The mapped class
+     *
+     * @return void
+     */
+    public function addDiscriminator($class, $key, $discriminatorClass)
+    {
+        if (!isset($this->discriminators[$class])) {
+            $this->discriminators[$class] = array();
+        }
+
+        if (!isset($this->discriminators[$class][$key])) {
+            $this->discriminators[$class][$key] = $discriminatorClass;
+        }
+    }
+
+    /**
+     * Add the Discriminator Column.
+     *
+     * @param string $class
+     * @param array $columnDef
+     *
+     * @return void
+     */
+    public function addDiscriminatorColumn($class, array $columnDef)
+    {
+        if (!isset($this->discriminatorColumns[$class])) {
+            $this->discriminatorColumns[$class] = $columnDef;
+        }
+    }
+
+    /**
+     * @param string $class
+     * @param string $type
+     *
+     * @return void
+     */
+    public function addInheritanceType($class, $type)
+    {
+        if (!isset($this->inheritanceTypes[$class])) {
+            $this->inheritanceTypes[$class] = $type;
+        }
     }
 
     /**
@@ -81,7 +135,28 @@ class DoctrineCollector
     {
         return $this->associations;
     }
+    /**
+     * @return array
+     */
+    public function getDiscriminators()
+    {
+        return $this->discriminators;
+    }
 
+    /**
+     * @return array
+     */
+    public function getDiscriminatorColumns()
+    {
+        return $this->discriminatorColumns;
+    }
+    /**
+     * @return array
+     */
+    public function getInheritanceTypes()
+    {
+        return $this->inheritanceTypes;
+    }
     /**
      * @return array
      */

--- a/Mapper/DoctrineORMMapper.php
+++ b/Mapper/DoctrineORMMapper.php
@@ -17,6 +17,12 @@ class DoctrineORMMapper implements EventSubscriber
 {
     protected $associations;
 
+    protected $discriminators;
+
+    protected $discriminatorColumns;
+
+    protected $inheritanceTypes;
+
     protected $doctrine;
 
     protected $indexes;
@@ -26,11 +32,15 @@ class DoctrineORMMapper implements EventSubscriber
      * @param array                                   $associations
      * @param array                                   $indexes
      */
-    public function __construct($doctrine, $associations = array(), $indexes = array())
+    public function __construct($doctrine, $associations = array(), $indexes = array(), $discriminators = array(), $discriminatorColumns = array(), $inheritanceTypes = array())
     {
         $this->doctrine = $doctrine;
         $this->associations = $associations;
         $this->indexes = $indexes;
+        $this->discriminatorColumns = $discriminatorColumns;
+        $this->discriminators = $discriminators;
+        $this->inheritanceTypes = $inheritanceTypes;
+
     }
 
     /**
@@ -56,6 +66,51 @@ class DoctrineORMMapper implements EventSubscriber
 
         $this->associations[$class][$field] = $options;
     }
+
+    /**
+     * Add a discriminator to a class.
+     *
+     * @param  string  $class               The Class
+     * @param  string  $key                 Key is the database value and values are the classes
+     * @param  string  $discriminatorclass  The mapped class
+     *
+     * @return void
+     */
+    public function addDiscriminator($class, $key, $discriminatorClass)
+    {
+        if (!isset($this->discriminators[$class])) {
+            $this->discriminators[$class] = array();
+        }
+
+        if (!isset($this->discriminators[$class][$key])) {
+            $this->discriminators[$class][$key] = $discriminatorClass;
+        }
+    }
+
+    /**
+     * @param string $class
+     * @param array $columnDef
+     * @return void
+     */
+    public function addDiscriminatorColumn($class, array $columnDef)
+    {
+        if (!isset($this->discriminatorColumns[$class])) {
+            $this->discriminatorColumns[$class] = $columnDef;
+        }
+    }
+    /**
+     * @param string $class
+     * @param string $type
+     *
+     * @return void
+     */
+    public function addInheritanceType($class, $type)
+    {
+        if (!isset($this->inheritanceTypes[$class])) {
+            $this->inheritanceTypes[$class] = $type;
+        }
+    }
+
 
     /**
      * @param string $class
@@ -85,6 +140,10 @@ class DoctrineORMMapper implements EventSubscriber
 
         $this->loadAssociations($metadata);
         $this->loadIndexes($metadata);
+
+        $this->loadDiscriminatorColumns($metadata);
+        $this->loadDiscriminators($metadata);
+        $this->loadInheritanceTypes($metadata);
     }
 
     /**
@@ -109,6 +168,75 @@ class DoctrineORMMapper implements EventSubscriber
 
                     call_user_func(array($metadata, $type), $mapping);
                 }
+            }
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404,  $e);
+        }
+    }
+
+    /**
+     * @param ClassMetadataInfo $metadata
+     *
+     * @throws \RuntimeException
+     */
+    private function loadDiscriminatorColumns(ClassMetadataInfo $metadata)
+    {
+
+        if (!array_key_exists($metadata->name, $this->discriminatorColumns)) {
+            return;
+        }
+
+        try {
+            if (isset($this->discriminatorColumns[$metadata->name])) {
+                $arrayDiscriminatorColumns = $this->discriminatorColumns[$metadata->name];
+                if (isset($metadata->discriminatorColumn)) {
+                    $arrayDiscriminatorColumns = array_merge($metadata->discriminatorColumn, $this->discriminatorColumns[$metadata->name]);
+                }
+                $metadata->setDiscriminatorColumn($arrayDiscriminatorColumns);
+            }
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404,  $e);
+        }
+    }
+
+    /**
+     * @param ClassMetadataInfo $metadata
+     *
+     * @throws \RuntimeException
+     */
+    private function loadInheritanceTypes(ClassMetadataInfo $metadata)
+    {
+
+        if (!array_key_exists($metadata->name, $this->inheritanceTypes)) {
+            return;
+        }
+        try {
+            if (isset($this->inheritanceTypes[$metadata->name])) {
+
+                $metadata->setInheritanceType($this->inheritanceTypes[$metadata->name]);
+            }
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404,  $e);
+        }
+    }
+
+    /**
+     * @param ClassMetadataInfo $metadata
+     *
+     * @throws \RuntimeException
+     */
+    private function loadDiscriminators(ClassMetadataInfo $metadata)
+    {
+         if (!array_key_exists($metadata->name, $this->discriminators)) {
+            return;
+        }
+
+        try {
+            foreach ($this->discriminators[$metadata->name] as $key => $class) {
+                if (in_array($key, $metadata->discriminatorMap)) {
+                    continue;
+                }
+                $metadata->setDiscriminatorMap(array($key=>$class));
             }
         } catch (\ReflectionException $e) {
             throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404,  $e);

--- a/Tests/Mapper/DoctrineORMMapperTest.php
+++ b/Tests/Mapper/DoctrineORMMapperTest.php
@@ -1,0 +1,69 @@
+<?php
+namespace Sonata\EasyExtendsBundle\Tests\Mapper;
+
+use Sonata\EasyExtendsBundle\Mapper\DoctrineORMMapper;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+class DoctrineORMMapperTest extends \PHPUnit_Framework_TestCase
+{
+    private $doctrine;
+    private $metadata;
+
+    public function setUp()
+    {
+        $this->doctrine = $this->getMock('\Symfony\Bundle\DoctrineBundle\Registry', array(), array(), '', false);
+        $this->metadata = $this->getMock('\Doctrine\ORM\Mapping\ClassMetadataInfo', array(), array(), '', false);
+    }
+
+    public function testLoadDiscriminators()
+    {
+        $this->metadata
+            ->expects($this->atLeastOnce())
+            ->method('setDiscriminatorMap')
+            ->with(array('key' => 'discriminator'));
+
+        $this->metadata->name = "class";
+        $mapper = new DoctrineORMMapper($this->doctrine);
+        $mapper->addDiscriminator('class', 'key', 'discriminator');
+
+        $r = new \ReflectionObject($mapper);
+        $m = $r->getMethod('loadDiscriminators');
+        $m->setAccessible(true);
+        $m->invoke($mapper, $this->metadata);
+    }
+
+    public function testLoadDiscriminatorColumns()
+    {
+        $this->metadata
+            ->expects($this->atLeastOnce())
+            ->method('setDiscriminatorColumn')
+            ->with(array('name' => 'disc'));
+
+        $this->metadata->name = "class";
+        $mapper = new DoctrineORMMapper($this->doctrine);
+        $mapper->addDiscriminatorColumn('class', array('name' => 'disc'));
+
+        $r = new \ReflectionObject($mapper);
+        $m = $r->getMethod('loadDiscriminatorColumns');
+        $m->setAccessible(true);
+        $m->invoke($mapper, $this->metadata);
+    }
+
+    public function testInheritanceTypes()
+    {
+        $this->metadata
+            ->expects($this->atLeastOnce())
+            ->method('setInheritanceType')
+            ->with(1);
+
+        $this->metadata->name = "class";
+        $mapper = new DoctrineORMMapper($this->doctrine);
+        $mapper->addInheritanceType('class', 1);
+
+        $r = new \ReflectionObject($mapper);
+        $m = $r->getMethod('loadInheritanceTypes');
+        $m->setAccessible(true);
+        $m->invoke($mapper, $this->metadata);
+    }
+
+}


### PR DESCRIPTION
You can now extend the inheritance of another class.

example:

``` php


        DoctrineCollector::getInstance()->addDiscriminator(
          '\Acme\AcmeDemoBundle\Entity',
          "MY",
          '\Acme\AcmeDemoBundle\MyEntity');

        DoctrineCollector::getInstance()->addDiscriminatorColumn(
          '\Acme\AcmeDemoBundle\Entity',
            array("name"=>"discr", "type"=>"string")
        );

        DoctrineCollector::getInstance()->addInheritanceType(
          '\Acme\AcmeDemoBundle\Entity',
            \Doctrine\ORM\Mapping\ClassMetadataInfo::INHERITANCE_TYPE_JOINED
        );

```
