### PR TITLE
test if dest option is an existing file

### DIFF
--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -52,9 +52,14 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dest = $input->getOption('dest');
-        if ($dest) {
-            $dest = realpath($dest);
+        $destOption = $input->getOption('dest');
+        if ($destOption) {
+            $dest = realpath($destOption);
+            if (false === $dest) {
+                $output->writeln('');
+                $output->writeln(sprintf('<error>The provided destination folder \'%s\' does not exist!</error>', $destOption));
+                return 0;
+            }
         } else {
             $dest = $this->getContainer()->get('kernel')->getRootDir();
         }


### PR DESCRIPTION
When the dest option was used with an incorrect path, the generated files were written to the root folder of the filesystem (eg C:\ on windows).
