### PR TITLE
Added support for addOverride method to allow for association and attribute overrides.

### DIFF
--- a/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
+++ b/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
@@ -35,8 +35,8 @@ class AddMapperInformationCompilerPass implements CompilerPassInterface
         $mapper = $container->getDefinition('sonata.easy_extends.doctrine.mapper');
 
         foreach (DoctrineCollector::getInstance()->getAssociations() as $class => $associations) {
-            foreach ($associations as $field => $options) {
-                $mapper->addMethodCall('addAssociation', array($class, $field, $options));
+            foreach ($associations as $type => $options) {
+                $mapper->addMethodCall('addAssociation', array($class, $type, $options));
             }
         }
 
@@ -57,6 +57,12 @@ class AddMapperInformationCompilerPass implements CompilerPassInterface
         foreach (DoctrineCollector::getInstance()->getIndexes() as $class => $indexes) {
             foreach ($indexes as $field => $options) {
                 $mapper->addMethodCall('addIndex', array($class, $field, $options));
+            }
+        }
+
+        foreach (DoctrineCollector::getInstance()->getOverrides() as $class => $overrides) {
+            foreach ($overrides as $type => $options) {
+                $mapper->addMethodCall('addOverride', array($class, $type, $options));
             }
         }
     }

--- a/Mapper/DoctrineCollector.php
+++ b/Mapper/DoctrineCollector.php
@@ -22,6 +22,8 @@ class DoctrineCollector
 
     protected $inheritanceTypes;
 
+    protected $overrides;
+
     private static $instance;
 
     public function __construct()
@@ -31,6 +33,7 @@ class DoctrineCollector
         $this->discriminatorColumns = array();
         $this->inheritanceTypes = array();
         $this->discriminators = array();
+        $this->overrides = array();
     }
 
     /**
@@ -132,12 +135,32 @@ class DoctrineCollector
     }
 
     /**
+     * @param $class
+     * @param $type
+     * @param  array $options
+     * @return void
+     */
+    public function addOverride($class, $type, array $options)
+    {
+        if (!isset($this->overrides[$class])) {
+            $this->overrides[$class] = array();
+        }
+
+        if (!isset($this->overrides[$class][$type])) {
+            $this->overrides[$class][$type] = array();
+        }
+
+        $this->overrides[$class][$type][] = $options;
+    }
+
+    /**
      * @return array
      */
     public function getAssociations()
     {
         return $this->associations;
     }
+
     /**
      * @return array
      */
@@ -153,6 +176,7 @@ class DoctrineCollector
     {
         return $this->discriminatorColumns;
     }
+
     /**
      * @return array
      */
@@ -160,11 +184,20 @@ class DoctrineCollector
     {
         return $this->inheritanceTypes;
     }
+
     /**
      * @return array
      */
     public function getIndexes()
     {
         return $this->indexes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOverrides()
+    {
+        return $this->overrides;
     }
 }

--- a/Tests/Mapper/DoctrineCollectorTest.php
+++ b/Tests/Mapper/DoctrineCollectorTest.php
@@ -21,5 +21,6 @@ class DoctrineCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $collector->getDiscriminatorColumns());
         $this->assertEquals(array(), $collector->getAssociations());
         $this->assertEquals(array(), $collector->getDiscriminators());
+        $this->assertEquals(array(), $collector->getOverrides());
     }
 }


### PR DESCRIPTION
Issue #29 requested the addition of a method that would allow one to remove an association so that it could possibly be re-added. That issue was closed out of fear of possibly breaking code.

I propose an alternative, which I feel is the better way to handle this, and that's to add a method called addOverride to both DoctrineCollector and DoctrineORMMapper, which will allow one to override both attributes and associations as necessary in a Doctrine supported manner.

An example in the code that I'm using is as follows:

```php
    $collector = DoctrineCollector::getInstance();

    $collector->addOverride($config['class']['user'], 'setAssociationOverride', array(
        'fieldName'   => 'groups',
        'joinColumns' => array(
            array(
                'name' => 'user_id',
                'referencedColumnName' => 'USER_ID',
                'onDelete' => 'CASCADE'
            )
        )
    ));
```

This allows one to call setAssociationOverride and setAttributeOverride as necessary to achieve what ever overrides are needed in your application.