### PR TITLE
Added support for custom namespace

### DIFF
--- a/Bundle/BundleMetadata.php
+++ b/Bundle/BundleMetadata.php
@@ -89,7 +89,7 @@ class BundleMetadata
     {
         // does not extends Application bundle ...
         return !(
-            strpos($this->getClass(), 'Application') === 0
+            strpos($this->getClass(), $this->configuration['namespace']) === 0
             || strpos($this->getClass(), 'Symfony') === 0
         );
     }
@@ -215,9 +215,15 @@ class BundleMetadata
 
         $this->name = $information[count($information) - 1];
         $this->vendor = $information[0];
-        $this->namespace = sprintf('%s\%s', $this->vendor, $information[1]);
-        $this->extendedDirectory = sprintf('%s/%s/%s', $this->configuration['application_dir'], $this->vendor, $information[1]);
-        $this->extendedNamespace = sprintf('Application\\%s\\%s', $this->vendor, $information[1]);
+        $this->namespace = sprintf('%s\\%s', $this->vendor, $information[1]);
+        $this->extendedDirectory =
+            str_replace(':vendor', $this->vendor, $this->configuration['application_dir']).
+            DIRECTORY_SEPARATOR.
+            $information[1];
+        $this->extendedNamespace = sprintf('%s\\%s',
+            str_replace(':vendor', $this->vendor, $this->configuration['namespace']),
+            $information[1]
+        );
         $this->valid = true;
 
         $this->ormMetadata = new OrmMetadata($this);

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -70,7 +70,8 @@ class BundleGenerator implements GeneratorInterface
      */
     protected function generateBundleFile(OutputInterface $output, BundleMetadata $bundleMetadata)
     {
-        $file = sprintf('%s/Application%s.php', $bundleMetadata->getExtendedDirectory(), $bundleMetadata->getName());
+        $application = explode('\\', $bundleMetadata->getExtendedNamespace())[0];
+        $file = sprintf('%s/%s%s.php', $bundleMetadata->getExtendedDirectory(), $application, $bundleMetadata->getName());
 
         if (is_file($file)) {
             return;
@@ -79,6 +80,7 @@ class BundleGenerator implements GeneratorInterface
         $output->writeln(sprintf('  > generating bundle file <comment>%s</comment>', $file));
 
         $string = Mustache::replace($this->getBundleTemplate(), array(
+            'application' => $application,
             'bundle' => $bundleMetadata->getName(),
             'namespace' => $bundleMetadata->getExtendedNamespace(),
         ));

--- a/Generator/OdmGenerator.php
+++ b/Generator/OdmGenerator.php
@@ -79,7 +79,14 @@ class OdmGenerator implements GeneratorInterface
                 $output->writeln(sprintf('   ~ <info>%s</info>', $fileName));
             } else {
                 $output->writeln(sprintf('   + <info>%s</info>', $fileName));
-                copy($src_file, $dest_file);
+
+                $mappingEntityTemplate = file_get_contents($src_file);
+
+                $string = Mustache::replace($mappingEntityTemplate, array(
+                    'namespace' => $bundleMetadata->getExtendedNamespace(),
+                ));
+
+                file_put_contents($dest_file, $string);
             }
         }
     }

--- a/Generator/OrmGenerator.php
+++ b/Generator/OrmGenerator.php
@@ -62,7 +62,14 @@ class OrmGenerator implements GeneratorInterface
                 $output->writeln(sprintf('   ~ <info>%s</info>', $fileName));
             } else {
                 $output->writeln(sprintf('   + <info>%s</info>', $fileName));
-                copy($src_file, $dest_file);
+
+                $mappingEntityTemplate = file_get_contents($src_file);
+
+                $string = Mustache::replace($mappingEntityTemplate, array(
+                    'namespace' => $bundleMetadata->getExtendedNamespace(),
+                ));
+
+                file_put_contents($dest_file, $string);
             }
         }
     }

--- a/Generator/PHPCRGenerator.php
+++ b/Generator/PHPCRGenerator.php
@@ -62,7 +62,14 @@ class PHPCRGenerator implements GeneratorInterface
                 $output->writeln(sprintf('   ~ <info>%s</info>', $fileName));
             } else {
                 $output->writeln(sprintf('   + <info>%s</info>', $fileName));
-                copy($src_file, $dest_file);
+
+                $mappingEntityTemplate = file_get_contents($src_file);
+
+                $string = Mustache::replace($mappingEntityTemplate, array(
+                    'namespace' => $bundleMetadata->getExtendedNamespace(),
+                ));
+
+                file_put_contents($dest_file, $string);
             }
         }
     }

--- a/Resources/doc/reference/introduction.rst
+++ b/Resources/doc/reference/introduction.rst
@@ -16,3 +16,7 @@ The command line will generate:
 
 You can optionally define a ``--dest`` option to the command with the target directory for the extended bundle creation.
 By default, this is set to ``app`` but you should probably set it to ``src``.
+
+You can optionally define a ``--namespace`` option to the command with the namespace for the extended bundle classes and directory structure.
+A special placeholder ``:vendor`` could be used and will be substitued with the bundle's `Vendor`.
+By default, this is set to ``Application\:vendor``.

--- a/Resources/doc/reference/why.rst
+++ b/Resources/doc/reference/why.rst
@@ -104,3 +104,5 @@ At last you can run:
 .. note::
 
     Note that the `--dest` option allows you to choose the target directory, such as `src`. Default destination is `app/`.
+
+    Also note that the `--namespace` option allows you to choose the base namespace, such as `Application\\Sonata`. Default destination is `Application\\:vendor`.

--- a/Resources/skeleton/bundle/bundle.mustache
+++ b/Resources/skeleton/bundle/bundle.mustache
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  *
  * @author <yourname> <youremail>
  */
-class Application{{ bundle }} extends Bundle
+class {{ application }}{{ bundle }} extends Bundle
 {
     /**
      * {@inheritdoc}

--- a/Tests/Bundle/BundleMetadataTest.php
+++ b/Tests/Bundle/BundleMetadataTest.php
@@ -27,7 +27,10 @@ class BundleMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = new \Sonata\AcmeBundle\SonataAcmeBundle();
 
-        $bundleMetadata = new BundleMetadata($bundle, array('application_dir' => 'app/Application'));
+        $bundleMetadata = new BundleMetadata($bundle, array(
+            'application_dir' => 'app/Application/:vendor',
+            'namespace' => 'Application\\:vendor',
+        ));
 
         $this->assertTrue($bundleMetadata->isExtendable());
         $this->assertTrue($bundleMetadata->isValid());
@@ -41,11 +44,27 @@ class BundleMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($bundle, $bundleMetadata->getBundle());
     }
 
+    public function testCustomNamespace()
+    {
+        $bundle = new \Sonata\AcmeBundle\SonataAcmeBundle();
+
+        $bundleMetadata = new BundleMetadata($bundle, array(
+            'application_dir' => 'app/Custom/:vendor',
+            'namespace' => 'Custom\\:vendor',
+        ));
+
+        $this->assertEquals('app/Custom/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
+        $this->assertEquals('Custom\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
+    }
+
     public function testApplicationNotExtendableBundle()
     {
         $bundle = new \Application\Sonata\NotExtendableBundle();
 
-        $bundleMetadata = new BundleMetadata($bundle, array('application_dir' => 'Application'));
+        $bundleMetadata = new BundleMetadata($bundle, array(
+            'application_dir' => 'Application',
+            'namespace' => 'Application',
+        ));
 
         $this->assertFalse($bundleMetadata->isValid());
         $this->assertFalse($bundleMetadata->isExtendable());
@@ -55,7 +74,10 @@ class BundleMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = new \Symfony\Bundle\NotExtendableBundle();
 
-        $bundleMetadata = new BundleMetadata($bundle, array('application_dir' => 'Application'));
+        $bundleMetadata = new BundleMetadata($bundle, array(
+            'application_dir' => 'Application',
+            'namespace' => 'Application',
+        ));
 
         $this->assertFalse($bundleMetadata->isValid());
         $this->assertFalse($bundleMetadata->isExtendable());
@@ -65,7 +87,10 @@ class BundleMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = new \Sonata\Bundle\AcmeBundle\LongNamespaceBundle();
 
-        $bundleMetadata = new BundleMetadata($bundle, array('application_dir' => 'Application'));
+        $bundleMetadata = new BundleMetadata($bundle, array(
+            'application_dir' => 'Application',
+            'namespace' => 'Application',
+        ));
 
         $this->assertFalse($bundleMetadata->isValid());
     }
@@ -74,7 +99,10 @@ class BundleMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = new \Sonata\AcmeBundle\AcmeBundle();
 
-        $bundleMetadata = new BundleMetadata($bundle, array('application_dir' => 'Application'));
+        $bundleMetadata = new BundleMetadata($bundle, array(
+            'application_dir' => 'Application',
+            'namespace' => 'Application',
+        ));
 
         $this->assertFalse($bundleMetadata->isValid());
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #60
Rebase of https://github.com/sonata-project/SonataEasyExtendsBundle/pull/61

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Added optional `--namespace` option to `GenerateCommand`
```

### Subject

Adding support for a custom namespace via the command line option `--namespace`, where a placeholder could be used (:vendor) for substituting the extended bundle's vendor name.
This defaults to Application\:vendor, as before.

Also mustache is now used for substituting `{{ namespace }}` in the `ord`, `odm` and `phpcr` mappings.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update the tests
- [X] Update the documentation