### PR TITLE
Added support for addOverride method to allow for association and attribute overrides

### DIFF
--- a/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
+++ b/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
@@ -64,5 +64,11 @@ class AddMapperInformationCompilerPass implements CompilerPassInterface
                 $mapper->addMethodCall('addUnique', array($class, $field, $options));
             }
         }
+
+        foreach (DoctrineCollector::getInstance()->getOverrides() as $class => $overrides) {
+            foreach ($overrides as $type => $options) {
+                $mapper->addMethodCall('addOverride', array($class, $type, $options));
+            }
+        }
     }
 }

--- a/Mapper/DoctrineCollector.php
+++ b/Mapper/DoctrineCollector.php
@@ -44,6 +44,11 @@ class DoctrineCollector
     protected $inheritanceTypes;
 
     /**
+     * @var array
+     */
+    protected $overrides;
+
+    /**
      * @var DoctrineCollector
      */
     private static $instance;
@@ -56,6 +61,7 @@ class DoctrineCollector
         $this->discriminatorColumns = array();
         $this->inheritanceTypes = array();
         $this->discriminators = array();
+        $this->overrides = array();
     }
 
     /**
@@ -167,6 +173,26 @@ class DoctrineCollector
     }
 
     /**
+     * Adds new override.
+     *
+     * @param string $class
+     * @param string $type
+     * @param array  $options
+     */
+    final public function addOverride($class, $type, array $options)
+    {
+        if (!isset($this->overrides[$class])) {
+            $this->overrides[$class] = array();
+        }
+
+        if (!isset($this->overrides[$class][$type])) {
+            $this->overrides[$class][$type] = array();
+        }
+
+        $this->overrides[$class][$type][] = $options;
+    }
+
+    /**
      * @return array
      */
     public function getAssociations()
@@ -212,5 +238,15 @@ class DoctrineCollector
     public function getUniques()
     {
         return $this->uniques;
+    }
+
+    /**
+     * Get all overrides.
+     *
+     * @return array
+     */
+    final public function getOverrides()
+    {
+        return $this->overrides;
     }
 }

--- a/Tests/Mapper/DoctrineCollectorTest.php
+++ b/Tests/Mapper/DoctrineCollectorTest.php
@@ -32,5 +32,6 @@ class DoctrineCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $collector->getDiscriminatorColumns());
         $this->assertEquals(array(), $collector->getAssociations());
         $this->assertEquals(array(), $collector->getDiscriminators());
+        $this->assertEquals(array(), $collector->getOverrides());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's a new feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixed #53
Rebase of #54

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new functionality to add ORM overrides
```

## Subject

Added new method `addOverride` to both DoctrineCollector and DoctrineORMMapper, which will allow you to override both attributes and associations as necessary in a Doctrine supported manner.