### PR TITLE
Drop old versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.2 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/framework-bundle": "^2.1 || ^3.0",
         "symfony/console": "^2.1 || ^3.0",
         "symfony/finder": "^2.1 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/framework-bundle": "^2.1 || ^3.0",
-        "symfony/console": "^2.1 || ^3.0",
-        "symfony/finder": "^2.1 || ^3.0"
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "symfony/console": "^2.8 || ^3.0",
+        "symfony/finder": "^2.8 || ^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/phpunit-bridge": "^2.8 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
I am targetting this branch, because dropping big versions of our dependencies is considered a BC-break.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- PHP 5.3 through 5.5 support was removed
- Symfony 2.1 through 2.7 was removed
```

## Subject

This prepares the 3.x release.
