### PR TITLE
Drop php 5

### DIFF
--- a/Bundle/BundleMetadata.php
+++ b/Bundle/BundleMetadata.php
@@ -220,7 +220,8 @@ class BundleMetadata
             str_replace(':vendor', $this->vendor, $this->configuration['application_dir']).
             DIRECTORY_SEPARATOR.
             $information[1];
-        $this->extendedNamespace = sprintf('%s\\%s',
+        $this->extendedNamespace = sprintf(
+            '%s\\%s',
             str_replace(':vendor', $this->vendor, $this->configuration['namespace']),
             $information[1]
         );

--- a/Bundle/BundleMetadata.php
+++ b/Bundle/BundleMetadata.php
@@ -21,9 +21,9 @@ class BundleMetadata
     protected $bundle;
 
     /**
-     * @var string|bool
+     * @var string
      */
-    protected $vendor = false;
+    protected $vendor;
 
     /**
      * @var bool
@@ -41,14 +41,14 @@ class BundleMetadata
     protected $name;
 
     /**
-     * @var bool
+     * @var string
      */
-    protected $extendedDirectory = false;
+    protected $extendedDirectory;
 
     /**
-     * @var bool
+     * @var string
      */
-    protected $extendedNamespace = false;
+    protected $extendedNamespace;
 
     /**
      * @var array
@@ -85,7 +85,7 @@ class BundleMetadata
     /**
      * @return bool
      */
-    public function isExtendable()
+    public function isExtendable(): bool
     {
         // does not extends Application bundle ...
         return !(
@@ -97,7 +97,7 @@ class BundleMetadata
     /**
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return get_class($this->bundle);
     }
@@ -105,7 +105,7 @@ class BundleMetadata
     /**
      * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->valid;
     }
@@ -113,7 +113,7 @@ class BundleMetadata
     /**
      * @return string
      */
-    public function getExtendedDirectory()
+    public function getExtendedDirectory(): string
     {
         return $this->extendedDirectory;
     }
@@ -121,7 +121,7 @@ class BundleMetadata
     /**
      * @return string
      */
-    public function getVendor()
+    public function getVendor(): string
     {
         return $this->vendor;
     }
@@ -129,7 +129,7 @@ class BundleMetadata
     /**
      * @return string
      */
-    public function getExtendedNamespace()
+    public function getExtendedNamespace(): string
     {
         return $this->extendedNamespace;
     }
@@ -137,7 +137,7 @@ class BundleMetadata
     /**
      * @return string
      */
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return $this->namespace;
     }
@@ -147,7 +147,7 @@ class BundleMetadata
      *
      * @return string return the bundle name
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -155,7 +155,7 @@ class BundleMetadata
     /**
      * @return BundleInterface
      */
-    public function getBundle()
+    public function getBundle(): BundleInterface
     {
         return $this->bundle;
     }
@@ -163,7 +163,7 @@ class BundleMetadata
     /**
      * @return OdmMetadata
      */
-    public function getOdmMetadata()
+    public function getOdmMetadata(): OdmMetadata
     {
         return $this->odmMetadata;
     }
@@ -171,7 +171,7 @@ class BundleMetadata
     /**
      * @return OrmMetadata
      */
-    public function getOrmMetadata()
+    public function getOrmMetadata(): OrmMetadata
     {
         return $this->ormMetadata;
     }
@@ -179,7 +179,7 @@ class BundleMetadata
     /**
      * @return PhpcrMetadata
      */
-    public function getPhpcrMetadata()
+    public function getPhpcrMetadata(): PhpcrMetadata
     {
         return $this->phpcrMetadata;
     }
@@ -191,7 +191,7 @@ class BundleMetadata
      * if the bundle does not respect this convention then the easy extends command will ignore
      * this bundle
      */
-    protected function buildInformation()
+    protected function buildInformation(): void
     {
         $information = explode('\\', $this->getClass());
 

--- a/Bundle/OdmMetadata.php
+++ b/Bundle/OdmMetadata.php
@@ -55,7 +55,7 @@ class OdmMetadata
     /**
      * @return string
      */
-    public function getMappingDocumentDirectory()
+    public function getMappingDocumentDirectory(): string
     {
         return $this->mappingDocumentDirectory;
     }
@@ -63,7 +63,7 @@ class OdmMetadata
     /**
      * @return string
      */
-    public function getExtendedMappingDocumentDirectory()
+    public function getExtendedMappingDocumentDirectory(): string
     {
         return $this->extendedMappingDocumentDirectory;
     }
@@ -71,7 +71,7 @@ class OdmMetadata
     /**
      * @return string
      */
-    public function getDocumentDirectory()
+    public function getDocumentDirectory(): string
     {
         return $this->documentDirectory;
     }
@@ -79,7 +79,7 @@ class OdmMetadata
     /**
      * @return string
      */
-    public function getExtendedDocumentDirectory()
+    public function getExtendedDocumentDirectory(): string
     {
         return $this->extendedDocumentDirectory;
     }
@@ -87,7 +87,7 @@ class OdmMetadata
     /**
      * @return string
      */
-    public function getExtendedSerializerDirectory()
+    public function getExtendedSerializerDirectory(): string
     {
         return $this->extendedSerializerDirectory;
     }
@@ -95,7 +95,7 @@ class OdmMetadata
     /**
      * @return array|\Iterator
      */
-    public function getDocumentMappingFiles()
+    public function getDocumentMappingFiles(): iterable
     {
         try {
             $f = new Finder();
@@ -111,7 +111,7 @@ class OdmMetadata
     /**
      * @return array
      */
-    public function getDocumentNames()
+    public function getDocumentNames(): array
     {
         $names = array();
 
@@ -133,7 +133,7 @@ class OdmMetadata
     /**
      * @return array|\Iterator
      */
-    public function getRepositoryFiles()
+    public function getRepositoryFiles(): iterable
     {
         try {
             $f = new Finder();

--- a/Bundle/OrmMetadata.php
+++ b/Bundle/OrmMetadata.php
@@ -55,7 +55,7 @@ class OrmMetadata
     /**
      * @return string
      */
-    public function getMappingEntityDirectory()
+    public function getMappingEntityDirectory(): string
     {
         return $this->mappingEntityDirectory;
     }
@@ -63,7 +63,7 @@ class OrmMetadata
     /**
      * @return string
      */
-    public function getExtendedMappingEntityDirectory()
+    public function getExtendedMappingEntityDirectory(): string
     {
         return $this->extendedMappingEntityDirectory;
     }
@@ -71,7 +71,7 @@ class OrmMetadata
     /**
      * @return string
      */
-    public function getEntityDirectory()
+    public function getEntityDirectory(): string
     {
         return $this->entityDirectory;
     }
@@ -79,7 +79,7 @@ class OrmMetadata
     /**
      * @return string
      */
-    public function getExtendedEntityDirectory()
+    public function getExtendedEntityDirectory(): string
     {
         return $this->extendedEntityDirectory;
     }
@@ -87,7 +87,7 @@ class OrmMetadata
     /**
      * @return string
      */
-    public function getExtendedSerializerDirectory()
+    public function getExtendedSerializerDirectory(): string
     {
         return $this->extendedSerializerDirectory;
     }
@@ -95,7 +95,7 @@ class OrmMetadata
     /**
      * @return array|\Iterator
      */
-    public function getEntityMappingFiles()
+    public function getEntityMappingFiles(): iterable
     {
         try {
             $f = new Finder();
@@ -112,7 +112,7 @@ class OrmMetadata
     /**
      * @return array
      */
-    public function getEntityNames()
+    public function getEntityNames(): array
     {
         $names = array();
 
@@ -135,7 +135,7 @@ class OrmMetadata
     /**
      * @return array|\Iterator
      */
-    public function getRepositoryFiles()
+    public function getRepositoryFiles(): iterable
     {
         try {
             $f = new Finder();

--- a/Bundle/PhpcrMetadata.php
+++ b/Bundle/PhpcrMetadata.php
@@ -55,7 +55,7 @@ class PhpcrMetadata
     /**
      * @return string
      */
-    public function getMappingDocumentDirectory()
+    public function getMappingDocumentDirectory(): string
     {
         return $this->mappingDocumentDirectory;
     }
@@ -63,7 +63,7 @@ class PhpcrMetadata
     /**
      * @return string
      */
-    public function getExtendedMappingDocumentDirectory()
+    public function getExtendedMappingDocumentDirectory(): string
     {
         return $this->extendedMappingDocumentDirectory;
     }
@@ -71,7 +71,7 @@ class PhpcrMetadata
     /**
      * @return string
      */
-    public function getDocumentDirectory()
+    public function getDocumentDirectory(): string
     {
         return $this->documentDirectory;
     }
@@ -79,7 +79,7 @@ class PhpcrMetadata
     /**
      * @return string
      */
-    public function getExtendedDocumentDirectory()
+    public function getExtendedDocumentDirectory(): string
     {
         return $this->extendedDocumentDirectory;
     }
@@ -87,7 +87,7 @@ class PhpcrMetadata
     /**
      * @return string
      */
-    public function getExtendedSerializerDirectory()
+    public function getExtendedSerializerDirectory(): string
     {
         return $this->extendedSerializerDirectory;
     }
@@ -95,7 +95,7 @@ class PhpcrMetadata
     /**
      * @return array|\Iterator
      */
-    public function getDocumentMappingFiles()
+    public function getDocumentMappingFiles(): iterable
     {
         try {
             $f = new Finder();
@@ -111,7 +111,7 @@ class PhpcrMetadata
     /**
      * @return array
      */
-    public function getDocumentNames()
+    public function getDocumentNames(): array
     {
         $names = array();
 
@@ -133,7 +133,7 @@ class PhpcrMetadata
     /**
      * @return array|\Iterator
      */
-    public function getRepositoryFiles()
+    public function getRepositoryFiles(): iterable
     {
         try {
             $f = new Finder();

--- a/Command/DumpMappingCommand.php
+++ b/Command/DumpMappingCommand.php
@@ -41,7 +41,10 @@ class DumpMappingCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $factory = $this->getContainer()->get('doctrine')->getManager($input->getArgument('manager'))->getMetadataFactory();
+        $factory = $this->getContainer()
+            ->get('doctrine')
+            ->getManager($input->getArgument('manager'))
+            ->getMetadataFactory();
 
         $metadata = $factory->getMetadataFor($input->getArgument('model'));
 

--- a/Command/DumpMappingCommand.php
+++ b/Command/DumpMappingCommand.php
@@ -27,7 +27,7 @@ class DumpMappingCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('sonata:easy-extends:dump-mapping');
         $this->setDescription('Dump some mapping information (debug only)');
@@ -39,7 +39,7 @@ class DumpMappingCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $factory = $this->getContainer()
             ->get('doctrine')

--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -43,7 +43,13 @@ EOT
         $this->setDescription('Create entities used by Sonata\'s bundles');
 
         $this->addArgument('bundle', InputArgument::IS_ARRAY, 'The bundle name to "easy-extends"');
-        $this->addOption('dest', 'd', InputOption::VALUE_OPTIONAL, 'The base folder where the Application will be created', false);
+        $this->addOption(
+            'dest',
+            'd',
+            InputOption::VALUE_OPTIONAL,
+            'The base folder where the Application will be created',
+            false
+        );
         $this->addOption('namespace', 'ns', InputOption::VALUE_OPTIONAL, 'The namespace for the classes', false);
     }
 
@@ -56,7 +62,10 @@ EOT
         if ($destOption) {
             $dest = realpath($destOption);
             if (false === $dest) {
-                throw new \RuntimeException(sprintf('The provided destination folder \'%s\' does not exist!', $destOption));
+                throw new \RuntimeException(sprintf(
+                    'The provided destination folder \'%s\' does not exist!',
+                    $destOption
+                ));
             }
         } else {
             $dest = $this->getContainer()->get('kernel')->getRootDir();
@@ -65,14 +74,22 @@ EOT
         $namespace = $input->getOption('namespace');
         if ($namespace) {
             if (!preg_match('/^(?:(?:[[:alnum:]]+|:vendor)\\\\?)+$/', $namespace)) {
-                throw new \InvalidArgumentException('The provided namespace \'%s\' is not a valid namespace!', $namespace);
+                throw new \InvalidArgumentException(
+                    'The provided namespace \'%s\' is not a valid namespace!',
+                    $namespace
+                );
             }
         } else {
             $namespace = 'Application\:vendor';
         }
 
         $configuration = array(
-            'application_dir' => sprintf('%s%s%s', $dest, DIRECTORY_SEPARATOR, str_replace('\\', DIRECTORY_SEPARATOR, $namespace)),
+            'application_dir' => sprintf(
+                '%s%s%s',
+                $dest,
+                DIRECTORY_SEPARATOR,
+                str_replace('\\', DIRECTORY_SEPARATOR, $namespace)
+            ),
             'namespace' => $namespace,
         );
 
@@ -100,7 +117,10 @@ EOT
                 $processed = $this->generate($bundleName, $configuration, $output);
 
                 if (!$processed) {
-                    throw new \RuntimeException(sprintf('<error>The bundle \'%s\' does not exist or not defined in the kernel file!</error>', $bundleName));
+                    throw new \RuntimeException(sprintf(
+                        '<error>The bundle \'%s\' does not exist or not defined in the kernel file!</error>',
+                        $bundleName
+                    ));
                 }
             }
         }
@@ -139,7 +159,10 @@ EOT
 
             // generate the bundle file
             if (!$bundleMetadata->isValid()) {
-                $output->writeln(sprintf('%s : <comment>wrong folder structure</comment>', $bundleMetadata->getClass()));
+                $output->writeln(sprintf(
+                    '%s : <comment>wrong folder structure</comment>',
+                    $bundleMetadata->getClass()
+                ));
 
                 continue;
             }

--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -29,7 +29,7 @@ class GenerateCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('sonata:easy-extends:generate')
@@ -56,7 +56,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $destOption = $input->getOption('dest');
         if ($destOption) {
@@ -137,7 +137,7 @@ EOT
      *
      * @return bool
      */
-    protected function generate($bundleName, array $configuration, $output)
+    protected function generate(string $bundleName, array $configuration, OutputInterface $output): bool
     {
         $processed = false;
 

--- a/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
+++ b/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
@@ -23,7 +23,7 @@ class AddMapperInformationCompilerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('doctrine')) {
             $container->removeDefinition('sonata.easy_extends.doctrine.mapper');

--- a/DependencyInjection/SonataEasyExtendsExtension.php
+++ b/DependencyInjection/SonataEasyExtendsExtension.php
@@ -26,7 +26,7 @@ class SonataEasyExtendsExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('generator.xml');

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -29,7 +29,7 @@ class BundleGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $this->generateBundleDirectory($output, $bundleMetadata);
         $this->generateBundleFile($output, $bundleMetadata);
@@ -39,7 +39,7 @@ class BundleGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    protected function generateBundleDirectory(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateBundleDirectory(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $directories = array(
             '',
@@ -68,7 +68,7 @@ class BundleGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    protected function generateBundleFile(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateBundleFile(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $application = explode('\\', $bundleMetadata->getExtendedNamespace())[0];
         $file = sprintf(
@@ -96,7 +96,7 @@ class BundleGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    protected function getBundleTemplate()
+    protected function getBundleTemplate(): string
     {
         return $this->bundleTemplate;
     }

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -71,7 +71,12 @@ class BundleGenerator implements GeneratorInterface
     protected function generateBundleFile(OutputInterface $output, BundleMetadata $bundleMetadata)
     {
         $application = explode('\\', $bundleMetadata->getExtendedNamespace())[0];
-        $file = sprintf('%s/%s%s.php', $bundleMetadata->getExtendedDirectory(), $application, $bundleMetadata->getName());
+        $file = sprintf(
+            '%s/%s%s.php',
+            $bundleMetadata->getExtendedDirectory(),
+            $application,
+            $bundleMetadata->getName()
+        );
 
         if (is_file($file)) {
             return;

--- a/Generator/GeneratorInterface.php
+++ b/Generator/GeneratorInterface.php
@@ -20,5 +20,5 @@ interface GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata);
+    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata): void;
 }

--- a/Generator/Mustache.php
+++ b/Generator/Mustache.php
@@ -17,9 +17,9 @@ class Mustache
      * @param string $string
      * @param array  $parameters
      *
-     * @return mixed
+     * @return string
      */
-    public static function replace($string, array $parameters)
+    public static function replace(string $string, array $parameters): string
     {
         $replacer = function ($match) use ($parameters) {
             return isset($parameters[$match[1]]) ? $parameters[$match[1]] : $match[0];
@@ -32,9 +32,9 @@ class Mustache
      * @param string $file
      * @param array  $parameters
      *
-     * @return mixed
+     * @return string
      */
-    public static function replaceFromFile($file, array $parameters)
+    public static function replaceFromFile(string $file, array $parameters): string
     {
         return self::replace(file_get_contents($file), $parameters);
     }

--- a/Generator/OdmGenerator.php
+++ b/Generator/OdmGenerator.php
@@ -35,7 +35,7 @@ class OdmGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $this->generateMappingDocumentFiles($output, $bundleMetadata);
         $this->generateDocumentFiles($output, $bundleMetadata);
@@ -45,7 +45,7 @@ class OdmGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    public function getDocumentTemplate()
+    public function getDocumentTemplate(): string
     {
         return $this->documentTemplate;
     }
@@ -53,7 +53,7 @@ class OdmGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    public function getDocumentRepositoryTemplate()
+    public function getDocumentRepositoryTemplate(): string
     {
         return $this->documentRepositoryTemplate;
     }
@@ -61,8 +61,10 @@ class OdmGenerator implements GeneratorInterface
     /**
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
+     *
+     * @return string
      */
-    protected function generateMappingDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateMappingDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata): string
     {
         $output->writeln(' - Copy document files');
 
@@ -102,8 +104,10 @@ class OdmGenerator implements GeneratorInterface
     /**
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
+     *
+     * @return string
      */
-    protected function generateDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata): string
     {
         $output->writeln(' - Generating document files');
 
@@ -147,8 +151,10 @@ class OdmGenerator implements GeneratorInterface
     /**
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
+     *
+     * @return string
      */
-    protected function generateDocumentRepositoryFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateDocumentRepositoryFiles(OutputInterface $output, BundleMetadata $bundleMetadata): string
     {
         $output->writeln(' - Generating document repository files');
 

--- a/Generator/OdmGenerator.php
+++ b/Generator/OdmGenerator.php
@@ -72,8 +72,16 @@ class OdmGenerator implements GeneratorInterface
             // copy mapping definition
             $fileName = substr($file->getFileName(), 0, strrpos($file->getFileName(), '.'));
 
-            $dest_file = sprintf('%s/%s', $bundleMetadata->getOdmMetadata()->getExtendedMappingDocumentDirectory(), $fileName);
-            $src_file = sprintf('%s/%s.skeleton', $bundleMetadata->getOdmMetadata()->getMappingDocumentDirectory(), $fileName);
+            $dest_file = sprintf(
+                '%s/%s',
+                $bundleMetadata->getOdmMetadata()->getExtendedMappingDocumentDirectory(),
+                $fileName
+            );
+            $src_file = sprintf(
+                '%s/%s.skeleton',
+                $bundleMetadata->getOdmMetadata()->getMappingDocumentDirectory(),
+                $fileName
+            );
 
             if (is_file($dest_file)) {
                 $output->writeln(sprintf('   ~ <info>%s</info>', $fileName));
@@ -147,8 +155,16 @@ class OdmGenerator implements GeneratorInterface
         $names = $bundleMetadata->getOdmMetadata()->getDocumentNames();
 
         foreach ($names as $name) {
-            $dest_file = sprintf('%s/%sRepository.php', $bundleMetadata->getOdmMetadata()->getExtendedDocumentDirectory(), $name);
-            $src_file = sprintf('%s/Base%sRepository.php', $bundleMetadata->getOdmMetadata()->getDocumentDirectory(), $name);
+            $dest_file = sprintf(
+                '%s/%sRepository.php',
+                $bundleMetadata->getOdmMetadata()->getExtendedDocumentDirectory(),
+                $name
+            );
+            $src_file = sprintf(
+                '%s/Base%sRepository.php',
+                $bundleMetadata->getOdmMetadata()->getDocumentDirectory(),
+                $name
+            );
 
             if (!is_file($src_file)) {
                 $output->writeln(sprintf('   ! <info>%sRepository</info>', $name));

--- a/Generator/OrmGenerator.php
+++ b/Generator/OrmGenerator.php
@@ -35,7 +35,7 @@ class OrmGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $this->generateMappingEntityFiles($output, $bundleMetadata);
         $this->generateEntityFiles($output, $bundleMetadata);
@@ -46,7 +46,7 @@ class OrmGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generateMappingEntityFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generateMappingEntityFiles(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $output->writeln(' - Copy entity files');
 
@@ -78,7 +78,7 @@ class OrmGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generateEntityFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generateEntityFiles(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $output->writeln(' - Generating entity files');
 
@@ -123,7 +123,7 @@ class OrmGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generateEntityRepositoryFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generateEntityRepositoryFiles(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $output->writeln(' - Generating entity repository files');
 
@@ -158,7 +158,7 @@ class OrmGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    public function getEntityTemplate()
+    public function getEntityTemplate(): string
     {
         return $this->entityTemplate;
     }
@@ -166,7 +166,7 @@ class OrmGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    public function getEntityRepositoryTemplate()
+    public function getEntityRepositoryTemplate(): string
     {
         return $this->entityRepositoryTemplate;
     }

--- a/Generator/PHPCRGenerator.php
+++ b/Generator/PHPCRGenerator.php
@@ -37,7 +37,7 @@ class PHPCRGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $this->generateMappingDocumentFiles($output, $bundleMetadata);
         $this->generateDocumentFiles($output, $bundleMetadata);
@@ -48,7 +48,7 @@ class PHPCRGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generateMappingDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generateMappingDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $output->writeln(' - Copy Document files');
 
@@ -88,7 +88,7 @@ class PHPCRGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generateDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generateDocumentFiles(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $output->writeln(' - Generating Document files');
 
@@ -145,7 +145,7 @@ class PHPCRGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    public function generateDocumentRepositoryFiles(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generateDocumentRepositoryFiles(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $output->writeln(' - Generating Document repository files');
 
@@ -188,7 +188,7 @@ class PHPCRGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    public function getDocumentTemplate()
+    public function getDocumentTemplate(): string
     {
         return $this->DocumentTemplate;
     }
@@ -196,7 +196,7 @@ class PHPCRGenerator implements GeneratorInterface
     /**
      * @return string
      */
-    public function getDocumentRepositoryTemplate()
+    public function getDocumentRepositoryTemplate(): string
     {
         return $this->DocumentRepositoryTemplate;
     }

--- a/Generator/PHPCRGenerator.php
+++ b/Generator/PHPCRGenerator.php
@@ -29,7 +29,9 @@ class PHPCRGenerator implements GeneratorInterface
     public function __construct()
     {
         $this->DocumentTemplate = file_get_contents(__DIR__.'/../Resources/skeleton/phpcr/document.mustache');
-        $this->DocumentRepositoryTemplate = file_get_contents(__DIR__.'/../Resources/skeleton/phpcr/repository.mustache');
+        $this->DocumentRepositoryTemplate = file_get_contents(
+            __DIR__.'/../Resources/skeleton/phpcr/repository.mustache'
+        );
     }
 
     /**
@@ -55,8 +57,16 @@ class PHPCRGenerator implements GeneratorInterface
             // copy mapping definition
             $fileName = substr($file->getFileName(), 0, strrpos($file->getFileName(), '.'));
 
-            $dest_file = sprintf('%s/%s', $bundleMetadata->getPhpcrMetadata()->getExtendedMappingDocumentDirectory(), $fileName);
-            $src_file = sprintf('%s/%s', $bundleMetadata->getPhpcrMetadata()->getMappingDocumentDirectory(), $file->getFileName());
+            $dest_file = sprintf(
+                '%s/%s',
+                $bundleMetadata->getPhpcrMetadata()->getExtendedMappingDocumentDirectory(),
+                $fileName
+            );
+            $src_file = sprintf(
+                '%s/%s',
+                $bundleMetadata->getPhpcrMetadata()->getMappingDocumentDirectory(),
+                $file->getFileName()
+            );
 
             if (is_file($dest_file)) {
                 $output->writeln(sprintf('   ~ <info>%s</info>', $fileName));
@@ -87,12 +97,24 @@ class PHPCRGenerator implements GeneratorInterface
         foreach ($names as $name) {
             $extendedName = $name;
 
-            $dest_file = sprintf('%s/%s.php', $bundleMetadata->getPhpcrMetadata()->getExtendedDocumentDirectory(), $name);
-            $src_file = sprintf('%s/%s.php', $bundleMetadata->getPhpcrMetadata()->getDocumentDirectory(), $extendedName);
+            $dest_file = sprintf(
+                '%s/%s.php',
+                $bundleMetadata->getPhpcrMetadata()->getExtendedDocumentDirectory(),
+                $name
+            );
+            $src_file = sprintf(
+                '%s/%s.php',
+                $bundleMetadata->getPhpcrMetadata()->getDocumentDirectory(),
+                $extendedName
+            );
 
             if (!is_file($src_file)) {
                 $extendedName = 'Base'.$name;
-                $src_file = sprintf('%s/%s.php', $bundleMetadata->getPhpcrMetadata()->getDocumentDirectory(), $extendedName);
+                $src_file = sprintf(
+                    '%s/%s.php',
+                    $bundleMetadata->getPhpcrMetadata()->getDocumentDirectory(),
+                    $extendedName
+                );
 
                 if (!is_file($src_file)) {
                     $output->writeln(sprintf('   ! <info>%s</info>', $extendedName));
@@ -130,8 +152,16 @@ class PHPCRGenerator implements GeneratorInterface
         $names = $bundleMetadata->getPhpcrMetadata()->getDocumentNames();
 
         foreach ($names as $name) {
-            $dest_file = sprintf('%s/%sRepository.php', $bundleMetadata->getPhpcrMetadata()->getExtendedDocumentDirectory(), $name);
-            $src_file = sprintf('%s/Base%sRepository.php', $bundleMetadata->getPhpcrMetadata()->getDocumentDirectory(), $name);
+            $dest_file = sprintf(
+                '%s/%sRepository.php',
+                $bundleMetadata->getPhpcrMetadata()->getExtendedDocumentDirectory(),
+                $name
+            );
+            $src_file = sprintf(
+                '%s/Base%sRepository.php',
+                $bundleMetadata->getPhpcrMetadata()->getDocumentDirectory(),
+                $name
+            );
 
             if (!is_file($src_file)) {
                 $output->writeln(sprintf('   ! <info>%sRepository</info>', $name));

--- a/Generator/SerializerGenerator.php
+++ b/Generator/SerializerGenerator.php
@@ -39,7 +39,7 @@ class SerializerGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata)
+    public function generate(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $this->generateOrmSerializer($output, $bundleMetadata);
         $this->generateOdmSerializer($output, $bundleMetadata);
@@ -50,7 +50,7 @@ class SerializerGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    protected function generateOrmSerializer(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateOrmSerializer(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $names = $bundleMetadata->getOrmMetadata()->getEntityNames();
 
@@ -73,7 +73,7 @@ class SerializerGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    protected function generateOdmSerializer(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generateOdmSerializer(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $names = $bundleMetadata->getOdmMetadata()->getDocumentNames();
 
@@ -102,7 +102,7 @@ class SerializerGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param BundleMetadata  $bundleMetadata
      */
-    protected function generatePhpcrSerializer(OutputInterface $output, BundleMetadata $bundleMetadata)
+    protected function generatePhpcrSerializer(OutputInterface $output, BundleMetadata $bundleMetadata): void
     {
         $names = $bundleMetadata->getPhpcrMetadata()->getDocumentNames();
 
@@ -134,7 +134,7 @@ class SerializerGenerator implements GeneratorInterface
      * @param string          $destFile
      * @param string          $name
      */
-    protected function writeSerializerFile(OutputInterface $output, BundleMetadata $bundleMetadata, $template, $destFile, $name)
+    protected function writeSerializerFile(OutputInterface $output, BundleMetadata $bundleMetadata, string $template, string $destFile, string $name): void
     {
         if (is_file($destFile)) {
             $output->writeln(sprintf('   ~ <info>%s</info>', $name));

--- a/Generator/SerializerGenerator.php
+++ b/Generator/SerializerGenerator.php
@@ -28,8 +28,12 @@ class SerializerGenerator implements GeneratorInterface
 
     public function __construct()
     {
-        $this->entitySerializerTemplate = file_get_contents(__DIR__.'/../Resources/skeleton/serializer/entity.mustache');
-        $this->documentSerializerTemplate = file_get_contents(__DIR__.'/../Resources/skeleton/serializer/document.mustache');
+        $this->entitySerializerTemplate = file_get_contents(
+            __DIR__.'/../Resources/skeleton/serializer/entity.mustache'
+        );
+        $this->documentSerializerTemplate = file_get_contents(
+            __DIR__.'/../Resources/skeleton/serializer/document.mustache'
+        );
     }
 
     /**
@@ -54,7 +58,11 @@ class SerializerGenerator implements GeneratorInterface
             $output->writeln(' - Generating ORM serializer files');
 
             foreach ($names as $name) {
-                $destFile = sprintf('%s/Entity.%s.xml', $bundleMetadata->getOrmMetadata()->getExtendedSerializerDirectory(), $name);
+                $destFile = sprintf(
+                    '%s/Entity.%s.xml',
+                    $bundleMetadata->getOrmMetadata()->getExtendedSerializerDirectory(),
+                    $name
+                );
 
                 $this->writeSerializerFile($output, $bundleMetadata, $this->entitySerializerTemplate, $destFile, $name);
             }
@@ -73,9 +81,19 @@ class SerializerGenerator implements GeneratorInterface
             $output->writeln(' - Generating ODM serializer files');
 
             foreach ($names as $name) {
-                $destFile = sprintf('%s/Document.%s.xml', $bundleMetadata->getOdmMetadata()->getExtendedSerializerDirectory(), $name);
+                $destFile = sprintf(
+                    '%s/Document.%s.xml',
+                    $bundleMetadata->getOdmMetadata()->getExtendedSerializerDirectory(),
+                    $name
+                );
 
-                $this->writeSerializerFile($output, $bundleMetadata, $this->documentSerializerTemplate, $destFile, $name);
+                $this->writeSerializerFile(
+                    $output,
+                    $bundleMetadata,
+                    $this->documentSerializerTemplate,
+                    $destFile,
+                    $name
+                );
             }
         }
     }
@@ -92,9 +110,19 @@ class SerializerGenerator implements GeneratorInterface
             $output->writeln(' - Generating PHPCR serializer files');
 
             foreach ($names as $name) {
-                $destFile = sprintf('%s/Document.%s.xml', $bundleMetadata->getPhpcrMetadata()->getExtendedSerializerDirectory(), $name);
+                $destFile = sprintf(
+                    '%s/Document.%s.xml',
+                    $bundleMetadata->getPhpcrMetadata()->getExtendedSerializerDirectory(),
+                    $name
+                );
 
-                $this->writeSerializerFile($output, $bundleMetadata, $this->documentSerializerTemplate, $destFile, $name);
+                $this->writeSerializerFile(
+                    $output,
+                    $bundleMetadata,
+                    $this->documentSerializerTemplate,
+                    $destFile,
+                    $name
+                );
             }
         }
     }

--- a/Mapper/DoctrineCollector.php
+++ b/Mapper/DoctrineCollector.php
@@ -67,7 +67,7 @@ class DoctrineCollector
     /**
      * @return DoctrineCollector
      */
-    public static function getInstance()
+    public static function getInstance(): DoctrineCollector
     {
         if (!self::$instance) {
             self::$instance = new self();
@@ -83,7 +83,7 @@ class DoctrineCollector
      * @param string $key                Key is the database value and values are the classes
      * @param string $discriminatorClass The mapped class
      */
-    public function addDiscriminator($class, $key, $discriminatorClass)
+    public function addDiscriminator(string $class, string $key, string $discriminatorClass): void
     {
         if (!isset($this->discriminators[$class])) {
             $this->discriminators[$class] = array();
@@ -100,7 +100,7 @@ class DoctrineCollector
      * @param string $class
      * @param array  $columnDef
      */
-    public function addDiscriminatorColumn($class, array $columnDef)
+    public function addDiscriminatorColumn(string $class, array $columnDef): void
     {
         if (!isset($this->discriminatorColumns[$class])) {
             $this->discriminatorColumns[$class] = $columnDef;
@@ -111,7 +111,7 @@ class DoctrineCollector
      * @param string $class
      * @param string $type
      */
-    public function addInheritanceType($class, $type)
+    public function addInheritanceType(string $class, string $type): void
     {
         if (!isset($this->inheritanceTypes[$class])) {
             $this->inheritanceTypes[$class] = $type;
@@ -123,7 +123,7 @@ class DoctrineCollector
      * @param string $type
      * @param array  $options
      */
-    public function addAssociation($class, $type, array $options)
+    public function addAssociation(string $class, string $type, array $options): void
     {
         if (!isset($this->associations[$class])) {
             $this->associations[$class] = array();
@@ -141,7 +141,7 @@ class DoctrineCollector
      * @param string $name
      * @param array  $columns
      */
-    public function addIndex($class, $name, array $columns)
+    public function addIndex(string $class, string $name, array $columns): void
     {
         if (!isset($this->indexes[$class])) {
             $this->indexes[$class] = array();
@@ -159,7 +159,7 @@ class DoctrineCollector
      * @param string $name
      * @param array  $columns
      */
-    public function addUnique($class, $name, array $columns)
+    public function addUnique(string $class, string $name, array $columns): void
     {
         if (!isset($this->indexes[$class])) {
             $this->uniques[$class] = array();
@@ -179,7 +179,7 @@ class DoctrineCollector
      * @param string $type
      * @param array  $options
      */
-    final public function addOverride($class, $type, array $options)
+    final public function addOverride(string $class, string $type, array $options): void
     {
         if (!isset($this->overrides[$class])) {
             $this->overrides[$class] = array();
@@ -195,7 +195,7 @@ class DoctrineCollector
     /**
      * @return array
      */
-    public function getAssociations()
+    public function getAssociations(): array
     {
         return $this->associations;
     }
@@ -203,7 +203,7 @@ class DoctrineCollector
     /**
      * @return array
      */
-    public function getDiscriminators()
+    public function getDiscriminators(): array
     {
         return $this->discriminators;
     }
@@ -211,7 +211,7 @@ class DoctrineCollector
     /**
      * @return array
      */
-    public function getDiscriminatorColumns()
+    public function getDiscriminatorColumns(): array
     {
         return $this->discriminatorColumns;
     }
@@ -219,7 +219,7 @@ class DoctrineCollector
     /**
      * @return array
      */
-    public function getInheritanceTypes()
+    public function getInheritanceTypes(): array
     {
         return $this->inheritanceTypes;
     }
@@ -227,7 +227,7 @@ class DoctrineCollector
     /**
      * @return array
      */
-    public function getIndexes()
+    public function getIndexes(): array
     {
         return $this->indexes;
     }
@@ -235,7 +235,7 @@ class DoctrineCollector
     /**
      * @return array
      */
-    public function getUniques()
+    public function getUniques(): array
     {
         return $this->uniques;
     }
@@ -245,7 +245,7 @@ class DoctrineCollector
      *
      * @return array
      */
-    final public function getOverrides()
+    final public function getOverrides(): array
     {
         return $this->overrides;
     }

--- a/Mapper/DoctrineORMMapper.php
+++ b/Mapper/DoctrineORMMapper.php
@@ -236,7 +236,11 @@ class DoctrineORMMapper implements EventSubscriber
                 }
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404, $e);
+            throw new \RuntimeException(sprintf(
+                'Error with class %s : %s',
+                $metadata->name,
+                $e->getMessage()
+            ), 404, $e);
         }
     }
 
@@ -255,12 +259,19 @@ class DoctrineORMMapper implements EventSubscriber
             if (isset($this->discriminatorColumns[$metadata->name])) {
                 $arrayDiscriminatorColumns = $this->discriminatorColumns[$metadata->name];
                 if (isset($metadata->discriminatorColumn)) {
-                    $arrayDiscriminatorColumns = array_merge($metadata->discriminatorColumn, $this->discriminatorColumns[$metadata->name]);
+                    $arrayDiscriminatorColumns = array_merge(
+                        $metadata->discriminatorColumn,
+                        $this->discriminatorColumns[$metadata->name]
+                    );
                 }
                 $metadata->setDiscriminatorColumn($arrayDiscriminatorColumns);
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404, $e);
+            throw new \RuntimeException(sprintf(
+                'Error with class %s : %s',
+                $metadata->name,
+                $e->getMessage()
+            ), 404, $e);
         }
     }
 
@@ -280,7 +291,11 @@ class DoctrineORMMapper implements EventSubscriber
                 $metadata->setInheritanceType($this->inheritanceTypes[$metadata->name]);
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404, $e);
+            throw new \RuntimeException(sprintf(
+                'Error with class %s : %s',
+                $metadata->name,
+                $e->getMessage()
+            ), 404, $e);
         }
     }
 
@@ -303,7 +318,11 @@ class DoctrineORMMapper implements EventSubscriber
                 $metadata->setDiscriminatorMap(array($key => $class));
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404, $e);
+            throw new \RuntimeException(sprintf(
+                'Error with class %s : %s',
+                $metadata->name,
+                $e->getMessage()
+            ), 404, $e);
         }
     }
 
@@ -353,9 +372,11 @@ class DoctrineORMMapper implements EventSubscriber
                 }
             }
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException(
-                sprintf('Error with class %s : %s', $metadata->name, $e->getMessage()), 404, $e
-            );
+            throw new \RuntimeException(sprintf(
+                'Error with class %s : %s',
+                $metadata->name,
+                $e->getMessage()
+            ), 404, $e);
         }
     }
 }

--- a/Mapper/DoctrineORMMapper.php
+++ b/Mapper/DoctrineORMMapper.php
@@ -83,7 +83,7 @@ class DoctrineORMMapper implements EventSubscriber
     /**
      * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return array(
             'loadClassMetadata',
@@ -95,7 +95,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $field
      * @param array  $options
      */
-    public function addAssociation($class, $field, array $options)
+    public function addAssociation(string $class, string $field, array $options): void
     {
         if (!isset($this->associations[$class])) {
             $this->associations[$class] = array();
@@ -111,7 +111,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $key                Key is the database value and values are the classes
      * @param string $discriminatorClass The mapped class
      */
-    public function addDiscriminator($class, $key, $discriminatorClass)
+    public function addDiscriminator(string $class, string $key, string $discriminatorClass): void
     {
         if (!isset($this->discriminators[$class])) {
             $this->discriminators[$class] = array();
@@ -126,7 +126,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $class
      * @param array  $columnDef
      */
-    public function addDiscriminatorColumn($class, array $columnDef)
+    public function addDiscriminatorColumn(string $class, array $columnDef): void
     {
         if (!isset($this->discriminatorColumns[$class])) {
             $this->discriminatorColumns[$class] = $columnDef;
@@ -137,7 +137,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $class
      * @param string $type
      */
-    public function addInheritanceType($class, $type)
+    public function addInheritanceType(string $class, string $type): void
     {
         if (!isset($this->inheritanceTypes[$class])) {
             $this->inheritanceTypes[$class] = $type;
@@ -149,7 +149,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $name
      * @param array  $columns
      */
-    public function addIndex($class, $name, array $columns)
+    public function addIndex(string $class, string $name, array $columns): void
     {
         if (!isset($this->indexes[$class])) {
             $this->indexes[$class] = array();
@@ -167,7 +167,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $name
      * @param array  $columns
      */
-    public function addUnique($class, $name, array $columns)
+    public function addUnique(string $class, string $name, array $columns): void
     {
         if (!isset($this->uniques[$class])) {
             $this->uniques[$class] = array();
@@ -187,7 +187,7 @@ class DoctrineORMMapper implements EventSubscriber
      * @param string $type
      * @param array  $options
      */
-    final public function addOverride($class, $type, array $options)
+    final public function addOverride(string $class, string $type, array $options): void
     {
         if (!isset($this->overrides[$class])) {
             $this->overrides[$class] = array();
@@ -197,9 +197,9 @@ class DoctrineORMMapper implements EventSubscriber
     }
 
     /**
-     * @param $eventArgs
+     * @param LoadClassMetadataEventArgs $eventArgs
      */
-    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
     {
         $metadata = $eventArgs->getClassMetadata();
 
@@ -218,7 +218,7 @@ class DoctrineORMMapper implements EventSubscriber
      *
      * @throws \RuntimeException
      */
-    private function loadAssociations(ClassMetadataInfo $metadata)
+    private function loadAssociations(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->associations)) {
             return;
@@ -249,7 +249,7 @@ class DoctrineORMMapper implements EventSubscriber
      *
      * @throws \RuntimeException
      */
-    private function loadDiscriminatorColumns(ClassMetadataInfo $metadata)
+    private function loadDiscriminatorColumns(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->discriminatorColumns)) {
             return;
@@ -280,7 +280,7 @@ class DoctrineORMMapper implements EventSubscriber
      *
      * @throws \RuntimeException
      */
-    private function loadInheritanceTypes(ClassMetadataInfo $metadata)
+    private function loadInheritanceTypes(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->inheritanceTypes)) {
             return;
@@ -304,7 +304,7 @@ class DoctrineORMMapper implements EventSubscriber
      *
      * @throws \RuntimeException
      */
-    private function loadDiscriminators(ClassMetadataInfo $metadata)
+    private function loadDiscriminators(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->discriminators)) {
             return;
@@ -329,7 +329,7 @@ class DoctrineORMMapper implements EventSubscriber
     /**
      * @param ClassMetadataInfo $metadata
      */
-    private function loadIndexes(ClassMetadataInfo $metadata)
+    private function loadIndexes(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->indexes)) {
             return;
@@ -343,7 +343,7 @@ class DoctrineORMMapper implements EventSubscriber
     /**
      * @param ClassMetadataInfo $metadata
      */
-    private function loadUniques(ClassMetadataInfo $metadata)
+    private function loadUniques(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->uniques)) {
             return;
@@ -359,7 +359,7 @@ class DoctrineORMMapper implements EventSubscriber
      *
      * @throws \RuntimeException
      */
-    private function loadOverrides(ClassMetadataInfo $metadata)
+    private function loadOverrides(ClassMetadataInfo $metadata): void
     {
         if (!array_key_exists($metadata->name, $this->overrides)) {
             return;

--- a/SonataEasyExtendsBundle.php
+++ b/SonataEasyExtendsBundle.php
@@ -27,7 +27,7 @@ class SonataEasyExtendsBundle extends Bundle
      *
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new AddMapperInformationCompilerPass());
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "symfony/framework-bundle": "^2.8 || ^3.0",
         "symfony/console": "^2.8 || ^3.0",
         "symfony/finder": "^2.8 || ^3.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a huge BC-break.

In case of bug fix, `2.x` **MUST** be targeted.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for PHP < 7.1
```

## Subject

<!-- Describe your Pull Request content here -->

This PR adds type hinting to classes.