### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/finder": "^2.3 || ^3.0"
+        "php": "^7.1",
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/finder": "^2.8 || ^3.2"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/phpunit-bridge": "^3.3",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
