### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/Tests/Bundle/BundleMetadataTest.php
+++ b/Tests/Bundle/BundleMetadataTest.php
@@ -19,9 +19,10 @@ require_once __DIR__.'/Fixtures/bundle1/SymfonyNotExtendableBundle.php';
 require_once __DIR__.'/Fixtures/bundle1/LongNamespaceBundle.php';
 require_once __DIR__.'/Fixtures/bundle1/AcmeBundle.php';
 
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 
-class BundleMetadataTest extends \PHPUnit_Framework_TestCase
+class BundleMetadataTest extends TestCase
 {
     public function testBundleMetadata()
     {

--- a/Tests/Bundle/OdmMetadataTest.php
+++ b/Tests/Bundle/OdmMetadataTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\EasyExtendsBundle\Tests\Bundle;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 use Sonata\EasyExtendsBundle\Bundle\OdmMetadata;
 
-class OdmMetadataTest extends \PHPUnit_Framework_TestCase
+class OdmMetadataTest extends TestCase
 {
     public function testDocumentNames()
     {
@@ -161,12 +162,12 @@ class OdmMetadataTest extends \PHPUnit_Framework_TestCase
      */
     private function getBundleMetadataMock($bundlePath)
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+        $bundle = $this->createMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->expects($this->any())
             ->method('getPath')
             ->will($this->returnValue($bundlePath));
 
-        $bundleMetadata = $this->getMock(
+        $bundleMetadata = $this->createMock(
             'Sonata\EasyExtendsBundle\Bundle\BundleMetadata',
             [],
             [$bundle],

--- a/Tests/Bundle/OrmMetadataTest.php
+++ b/Tests/Bundle/OrmMetadataTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\EasyExtendsBundle\Tests\Bundle;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 use Sonata\EasyExtendsBundle\Bundle\OrmMetadata;
 
-class OrmMetadataTest extends \PHPUnit_Framework_TestCase
+class OrmMetadataTest extends TestCase
 {
     public function testEntityNames()
     {
@@ -163,12 +164,12 @@ class OrmMetadataTest extends \PHPUnit_Framework_TestCase
      */
     private function getBundleMetadataMock($bundlePath)
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+        $bundle = $this->createMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->expects($this->any())
             ->method('getPath')
             ->will($this->returnValue($bundlePath));
 
-        $bundleMetadata = $this->getMock(
+        $bundleMetadata = $this->createMock(
             'Sonata\EasyExtendsBundle\Bundle\BundleMetadata',
             [],
             [$bundle],

--- a/Tests/Bundle/PhpcrMetadataTest.php
+++ b/Tests/Bundle/PhpcrMetadataTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\EasyExtendsBundle\Tests\Bundle;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 use Sonata\EasyExtendsBundle\Bundle\PhpcrMetadata;
 
-class PhpcrMetadataTest extends \PHPUnit_Framework_TestCase
+class PhpcrMetadataTest extends TestCase
 {
     public function testDocumentNames()
     {
@@ -161,12 +162,12 @@ class PhpcrMetadataTest extends \PHPUnit_Framework_TestCase
      */
     private function getBundleMetadataMock($bundlePath)
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+        $bundle = $this->createMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->expects($this->any())
             ->method('getPath')
             ->will($this->returnValue($bundlePath));
 
-        $bundleMetadata = $this->getMock(
+        $bundleMetadata = $this->createMock(
             'Sonata\EasyExtendsBundle\Bundle\BundleMetadata',
             [],
             [$bundle],

--- a/Tests/Generator/MustacheTest.php
+++ b/Tests/Generator/MustacheTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\EasyExtendsBundle\Tests\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Generator\Mustache;
 
-class MustacheTest extends \PHPUnit_Framework_TestCase
+class MustacheTest extends TestCase
 {
     public function testMustache()
     {

--- a/Tests/Mapper/DoctrineCollectorTest.php
+++ b/Tests/Mapper/DoctrineCollectorTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\EasyExtendsBundle\Tests\Mapper;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
 
-class DoctrineCollectorTest extends \PHPUnit_Framework_TestCase
+class DoctrineCollectorTest extends TestCase
 {
     /**
      * @covers \Sonata\EasyExtendsBundle\Mapper\DoctrineCollector::getIndexes

--- a/Tests/Mapper/DoctrineORMMapperTest.php
+++ b/Tests/Mapper/DoctrineORMMapperTest.php
@@ -13,9 +13,10 @@ namespace Sonata\EasyExtendsBundle\Tests\Mapper;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Mapper\DoctrineORMMapper;
 
-class DoctrineORMMapperTest extends \PHPUnit_Framework_TestCase
+class DoctrineORMMapperTest extends TestCase
 {
     /**
      * @var ManagerRegistry
@@ -29,8 +30,8 @@ class DoctrineORMMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->doctrine = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry', [], [], '', false);
-        $this->metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadataInfo', [], [], '', false);
+        $this->doctrine = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry', [], [], '', false);
+        $this->metadata = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo', [], [], '', false);
     }
 
     public function testLoadDiscriminators()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809