### PR TITLE
Fix autoload routes for testing

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -130,7 +130,7 @@ EOT
             $processed = true;
             $bundleMetadata = new BundleMetadata($bundle, $configuration);
 
-            // generate the bundle file
+            // generate the bundle file.
             if (!$bundleMetadata->isExtendable()) {
                 $output->writeln(sprintf('Ignoring bundle : "<comment>%s</comment>"', $bundleMetadata->getClass()));
 

--- a/tests/autoload.php.dist
+++ b/tests/autoload.php.dist
@@ -3,9 +3,9 @@
 // if the bundle is within a symfony project, try to reuse the project's autoload
 
 $files = array(
-    __DIR__.'/../../vendor/autoload.php',
-    __DIR__.'/../../../../../app/autoload.php',
-    __DIR__.'/../../../../../apps/autoload.php',
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/../../../../app/autoload.php',
+    __DIR__.'/../../../../apps/autoload.php',
 );
 
 $autoload = false;


### PR DESCRIPTION
This is a missing change from refactor structure, pretty critical because it makes test unable to execute but still gives a green build