### PR TITLE
Make commands public

### DIFF
--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="Sonata\EasyExtendsBundle\Command\DumpMappingCommand" class="Sonata\EasyExtendsBundle\Command\DumpMappingCommand">
+        <service id="Sonata\EasyExtendsBundle\Command\DumpMappingCommand" class="Sonata\EasyExtendsBundle\Command\DumpMappingCommand" public="true">
             <tag name="console.command"/>
         </service>
-        <service id="Sonata\EasyExtendsBundle\Command\GenerateCommand" class="Sonata\EasyExtendsBundle\Command\GenerateCommand">
+        <service id="Sonata\EasyExtendsBundle\Command\GenerateCommand" class="Sonata\EasyExtendsBundle\Command\GenerateCommand" public="true">
             <tag name="console.command"/>
         </service>
     </services>


### PR DESCRIPTION
This is probably needed for Symfony 3.2 through 3.3
Refs #162 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- commands are now usable with Symfony 3.2 - 3.3
```
