### PR TITLE
Add option for namespace prefix to generate command

### DIFF
--- a/docs/reference/why.rst
+++ b/docs/reference/why.rst
@@ -100,9 +100,16 @@ At last you can run:
 
     php app/console sonata:easy-extends:generate YourVBBundleName
 
+Command Options
+---------------
 
-.. note::
+There are few options that you can add when executing command:
 
-    Note that the `--dest` option allows you to choose the target directory, such as `src`. Default destination is `app/`.
-
-    Also note that the `--namespace` option allows you to choose the base namespace, such as `Application\\Sonata`. Default destination is `Application\\:vendor`.
+* the ``--dest`` option allows you to choose the target directory, such
+  as `src`. The default destination is the directory of your Kernel.
+* the ``--namespace`` option allows you to choose the base namespace, such
+  as `Application\\Sonata`. The default destination is `Application\\:vendor`.
+* the ``--namespace_prefix`` option allows to provide a prefix for your namespace,
+  this option is added because of the new directory structure that symfony-flex
+  brings us. There is no Default value so if you are using flex you should
+  use this option with the ``App`` value.

--- a/src/Bundle/BundleMetadata.php
+++ b/src/Bundle/BundleMetadata.php
@@ -71,6 +71,11 @@ class BundleMetadata
     protected $phpcrMetadata = null;
 
     /**
+     * @var string
+     */
+    private $application;
+
+    /**
      * @param BundleInterface $bundle
      * @param array           $configuration
      */
@@ -153,6 +158,14 @@ class BundleMetadata
     }
 
     /**
+     * @return string
+     */
+    public function getApplication()
+    {
+        return $this->application;
+    }
+
+    /**
      * @return BundleInterface
      */
     public function getBundle()
@@ -220,10 +233,13 @@ class BundleMetadata
             str_replace(':vendor', $this->vendor, $this->configuration['application_dir']).
             DIRECTORY_SEPARATOR.
             $information[1];
-        $this->extendedNamespace = sprintf('%s\\%s',
+        $this->extendedNamespace = sprintf(
+            '%s%s\\%s',
+            $this->configuration['namespace_prefix'],
             str_replace(':vendor', $this->vendor, $this->configuration['namespace']),
             $information[1]
         );
+        $this->application = explode('\\', $this->configuration['namespace'])[0];
         $this->valid = true;
 
         $this->ormMetadata = new OrmMetadata($this);

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -45,6 +45,7 @@ EOT
         $this->addArgument('bundle', InputArgument::IS_ARRAY, 'The bundle name to "easy-extends"');
         $this->addOption('dest', 'd', InputOption::VALUE_OPTIONAL, 'The base folder where the Application will be created', false);
         $this->addOption('namespace', 'ns', InputOption::VALUE_OPTIONAL, 'The namespace for the classes', false);
+        $this->addOption('namespace_prefix', 'nsp', InputOption::VALUE_OPTIONAL, 'The namespace prefix for the classes', false);
     }
 
     /**
@@ -74,7 +75,12 @@ EOT
         $configuration = [
             'application_dir' => sprintf('%s%s%s', $dest, DIRECTORY_SEPARATOR, str_replace('\\', DIRECTORY_SEPARATOR, $namespace)),
             'namespace' => $namespace,
+            'namespace_prefix' => '',
         ];
+
+        if ($namespacePrefix = $input->getOption('namespace_prefix')) {
+            $configuration['namespace_prefix'] = rtrim($namespacePrefix, '\\').'\\';
+        }
 
         $bundleNames = $input->getArgument('bundle');
 
@@ -100,7 +106,10 @@ EOT
                 $processed = $this->generate($bundleName, $configuration, $output);
 
                 if (!$processed) {
-                    throw new \RuntimeException(sprintf('<error>The bundle \'%s\' does not exist or not defined in the kernel file!</error>', $bundleName));
+                    throw new \RuntimeException(sprintf(
+                        '<error>The bundle \'%s\' does not exist or is not registered in the kernel!</error>',
+                        $bundleName
+                    ));
                 }
             }
         }
@@ -139,7 +148,10 @@ EOT
 
             // generate the bundle file
             if (!$bundleMetadata->isValid()) {
-                $output->writeln(sprintf('%s : <comment>wrong folder structure</comment>', $bundleMetadata->getClass()));
+                $output->writeln(sprintf(
+                    '%s : <comment>wrong directory structure</comment>',
+                    $bundleMetadata->getClass()
+                ));
 
                 continue;
             }

--- a/src/Generator/BundleGenerator.php
+++ b/src/Generator/BundleGenerator.php
@@ -70,7 +70,7 @@ class BundleGenerator implements GeneratorInterface
      */
     protected function generateBundleFile(OutputInterface $output, BundleMetadata $bundleMetadata)
     {
-        $application = explode('\\', $bundleMetadata->getExtendedNamespace())[0];
+        $application = $bundleMetadata->getApplication();
         $file = sprintf('%s/%s%s.php', $bundleMetadata->getExtendedDirectory(), $application, $bundleMetadata->getName());
 
         if (is_file($file)) {

--- a/tests/Bundle/BundleMetadataTest.php
+++ b/tests/Bundle/BundleMetadataTest.php
@@ -31,6 +31,7 @@ class BundleMetadataTest extends TestCase
         $bundleMetadata = new BundleMetadata($bundle, [
             'application_dir' => 'app/Application/:vendor',
             'namespace' => 'Application\\:vendor',
+            'namespace_prefix' => '',
         ]);
 
         $this->assertTrue($bundleMetadata->isExtendable());
@@ -52,6 +53,7 @@ class BundleMetadataTest extends TestCase
         $bundleMetadata = new BundleMetadata($bundle, [
             'application_dir' => 'app/Custom/:vendor',
             'namespace' => 'Custom\\:vendor',
+            'namespace_prefix' => '',
         ]);
 
         $this->assertEquals('app/Custom/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
@@ -65,6 +67,7 @@ class BundleMetadataTest extends TestCase
         $bundleMetadata = new BundleMetadata($bundle, [
             'application_dir' => 'Application',
             'namespace' => 'Application',
+            'namespace_prefix' => '',
         ]);
 
         $this->assertFalse($bundleMetadata->isValid());
@@ -78,6 +81,7 @@ class BundleMetadataTest extends TestCase
         $bundleMetadata = new BundleMetadata($bundle, [
             'application_dir' => 'Application',
             'namespace' => 'Application',
+            'namespace_prefix' => '',
         ]);
 
         $this->assertFalse($bundleMetadata->isValid());
@@ -91,6 +95,7 @@ class BundleMetadataTest extends TestCase
         $bundleMetadata = new BundleMetadata($bundle, [
             'application_dir' => 'Application',
             'namespace' => 'Application',
+            'namespace_prefix' => '',
         ]);
 
         $this->assertFalse($bundleMetadata->isValid());
@@ -103,8 +108,28 @@ class BundleMetadataTest extends TestCase
         $bundleMetadata = new BundleMetadata($bundle, [
             'application_dir' => 'Application',
             'namespace' => 'Application',
+            'namespace_prefix' => '',
         ]);
 
         $this->assertFalse($bundleMetadata->isValid());
+    }
+
+    public function testWithNamespacePrefix()
+    {
+        $bundle = new \Sonata\AcmeBundle\SonataAcmeBundle();
+
+        $bundleMetadata = new BundleMetadata($bundle, [
+            'application_dir' => 'src/Application/:vendor',
+            'namespace' => 'Application\\:vendor',
+            'namespace_prefix' => 'App\\',
+        ]);
+
+        $this->assertEquals('SonataAcmeBundle', $bundleMetadata->getName());
+        $this->assertEquals('Sonata', $bundleMetadata->getVendor());
+        $this->assertEquals('Application', $bundleMetadata->getApplication());
+        $this->assertEquals('Sonata\AcmeBundle', $bundleMetadata->getNamespace());
+        $this->assertEquals('src/Application/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
+        $this->assertEquals('App\Application\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
+        $this->assertSame($bundle, $bundleMetadata->getBundle());
     }
 }

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EasyExtendsBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AcmeBundle\SonataAcmeBundle;
+use Sonata\EasyExtendsBundle\Command\GenerateCommand;
+use Sonata\EasyExtendsBundle\Generator\GeneratorInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class GenerateCommandTest extends TestCase
+{
+    /**
+     * @dataProvider executeData
+     */
+    public function testExecute($args)
+    {
+        $commandTester = $this->buildCommand($this->mockContainer());
+        $commandTester->execute($args);
+
+        $this->assertContains(
+            'done!',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function executeData()
+    {
+        return [
+            [
+                [
+                    '--dest' => 'src',
+                    'bundle' => ['SonataAcmeBundle'],
+                ],
+            ],
+            [
+                [
+                    '--dest' => 'src',
+                    'bundle' => ['SonataAcmeBundle'],
+                    '--namespace' => 'Application\\Sonata',
+                ],
+            ],
+            [
+                [
+                    '--dest' => 'src',
+                    'bundle' => ['SonataAcmeBundle'],
+                    '--namespace_prefix' => 'App',
+                ],
+            ],
+            [
+                [
+                    '--dest' => 'src',
+                    'bundle' => ['SonataAcmeBundle'],
+                    '--namespace' => 'Application\\Sonata',
+                    '--namespace_prefix' => 'App',
+                ],
+            ],
+        ];
+    }
+
+    public function testExecuteWrongDest()
+    {
+        $commandTester = $this->buildCommand($this->createMock(ContainerInterface::class));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("The provided destination folder 'fakedest' does not exist!");
+
+        $commandTester->execute([
+            '--dest' => 'fakedest',
+        ]);
+    }
+
+    public function testNoArgument()
+    {
+        $commandTester = $this->buildCommand($this->mockContainerWithKernel());
+
+        $commandTester->execute([
+            '--dest' => 'src',
+        ]);
+
+        $this->assertContains(
+            'You must provide a bundle name!',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testFakeBundleName()
+    {
+        $commandTester = $this->buildCommand($this->mockContainerWithKernel());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("The bundle 'FakeBundle' does not exist or is not registered in the kernel!");
+
+        $commandTester->execute([
+            '--dest' => 'src',
+            'bundle' => ['FakeBundle'],
+        ]);
+
+        $this->assertContains(
+            'You must provide a bundle name!',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testNotExtendableBundle()
+    {
+        $commandTester = $this->buildCommand($this->mockContainerWithKernel(new \Symfony\Bundle\NotExtendableBundle()));
+
+        $commandTester->execute([
+            '--dest' => 'src',
+            'bundle' => ['NotExtendableBundle'],
+        ]);
+
+        $this->assertContains(
+            sprintf('Ignoring bundle : "Symfony\Bundle\NotExtendableBundle"'),
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testInvalidFolderStructure()
+    {
+        $commandTester = $this->buildCommand(
+            $this->mockContainerWithKernel(new \Application\Sonata\NotExtendableBundle())
+        );
+
+        $commandTester->execute([
+            '--dest' => 'src',
+            'bundle' => ['NotExtendableBundle'],
+        ]);
+
+        $this->assertContains(
+            sprintf('Application\Sonata\NotExtendableBundle : wrong directory structure'),
+            $commandTester->getDisplay()
+        );
+    }
+
+    private function buildCommand($container)
+    {
+        $command = new GenerateCommand();
+        $command->setContainer($container);
+
+        return new CommandTester($command);
+    }
+
+    private function mockContainer()
+    {
+        $containerMock = $this->mockContainerWithKernel();
+
+        $containerMock->expects($this->exactly(6))
+            ->method('get')
+            ->willReturn($this->mockGenerator());
+
+        return $containerMock;
+    }
+
+    private function mockContainerWithKernel($kernelReturnValue = null)
+    {
+        $containerMock = $this->createMock(ContainerInterface::class);
+
+        $containerMock->expects($this->at(0))
+            ->method('get')
+            ->with('kernel')
+            ->willReturn($this->mockKernel($kernelReturnValue));
+
+        return $containerMock;
+    }
+
+    private function mockKernel($returnValue)
+    {
+        $kernelMock = $this->createMock(KernelInterface::class);
+
+        $kernelMock->expects($this->once())
+            ->method('getBundles')
+            ->willReturn([
+                $returnValue ?: new SonataAcmeBundle(),
+            ]);
+
+        return $kernelMock;
+    }
+
+    private function mockGenerator()
+    {
+        $generatorMock = $this->createMock(GeneratorInterface::class);
+
+        $generatorMock->expects($this->exactly(5))
+            ->method('generate');
+
+        return $generatorMock;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am adding new option to generate command.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #164

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new `namespace_prefix` option to generate command
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the documentation
- [x] Update the tests

## Subject

With new symfony-flex structure `src` folder is now mapped to `App` namespace. If using EasyExtends generate command you will get wrong namespace.

Example:

`bin/console sonata:easy-extends:generate SonataUserBundle`

directory: `src/Application/Sonata/UserBundle`
namespace: `Application\Sonata\UserBundle`

while it should be `App\Application\Sonata\UserBundle`

if we add `--namespace="App\Application\:vendor"` we get:

directory: `src/App/Application/Sonata/UserBundle`
namespace: `App\Application\Sonata\UserBundle`

problem here is that `src` is `App` namespace so we now need `App\App\Application\Sonata\UserBundle`

With this PR we get an additional option for command as @jordisala1991 suggested and it looks like:

`bin/console sonata:easy-extends:generate SonataUserBundle --namespace_prefix="App"`

we finally get:

directory: `src/Application/Sonata/UserBundle`
namespace: `App\Application\Sonata\UserBundle`

but now there is a new problem, the bundle name is `AppSonataUserBundle` instead of `ApplicationSonataUserBundle` because of https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/src/Generator/BundleGenerator.php#L73 
This means all the docs that mention `ApplicationSonata*Bundle` will be wrong.

Any suggestion on how to continue with this?