### PR TITLE
clear doctrine collector when it has been get all information from it

### DIFF
--- a/src/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddMapperInformationCompilerPass.php
@@ -70,5 +70,7 @@ class AddMapperInformationCompilerPass implements CompilerPassInterface
                 $mapper->addMethodCall('addOverride', [$class, $type, $options]);
             }
         }
+
+        DoctrineCollector::getInstance()->clear();
     }
 }

--- a/src/Mapper/DoctrineCollector.php
+++ b/src/Mapper/DoctrineCollector.php
@@ -55,13 +55,7 @@ class DoctrineCollector
 
     public function __construct()
     {
-        $this->associations = [];
-        $this->indexes = [];
-        $this->uniques = [];
-        $this->discriminatorColumns = [];
-        $this->inheritanceTypes = [];
-        $this->discriminators = [];
-        $this->overrides = [];
+        $this->initialize();
     }
 
     /**
@@ -248,5 +242,21 @@ class DoctrineCollector
     final public function getOverrides()
     {
         return $this->overrides;
+    }
+
+    public function clear()
+    {
+        $this->initialize();
+    }
+
+    private function initialize()
+    {
+        $this->associations = [];
+        $this->indexes = [];
+        $this->uniques = [];
+        $this->discriminatorColumns = [];
+        $this->inheritanceTypes = [];
+        $this->discriminators = [];
+        $this->overrides = [];
     }
 }

--- a/tests/Mapper/DoctrineCollectorTest.php
+++ b/tests/Mapper/DoctrineCollectorTest.php
@@ -35,4 +35,26 @@ class DoctrineCollectorTest extends TestCase
         $this->assertEquals([], $collector->getDiscriminators());
         $this->assertEquals([], $collector->getOverrides());
     }
+
+    public function testClear()
+    {
+        $collector = DoctrineCollector::getInstance();
+        $collector->addIndex(\stdClass::class, 'name', ['column']);
+        $collector->addUnique(\stdClass::class, 'name', ['column']);
+        $collector->addInheritanceType(\stdClass::class, 'type');
+        $collector->addDiscriminatorColumn(\stdClass::class, ['columnDef']);
+        $collector->addAssociation(\stdClass::class, 'type', ['options']);
+        $collector->addDiscriminator(\stdClass::class, 'key', 'discriminatorClass');
+        $collector->addOverride(\stdClass::class, 'type', ['options']);
+
+        $collector->clear();
+
+        $this->assertEquals([], $collector->getIndexes());
+        $this->assertEquals([], $collector->getUniques());
+        $this->assertEquals([], $collector->getInheritanceTypes());
+        $this->assertEquals([], $collector->getDiscriminatorColumns());
+        $this->assertEquals([], $collector->getAssociations());
+        $this->assertEquals([], $collector->getDiscriminators());
+        $this->assertEquals([], $collector->getOverrides());
+    }
 }


### PR DESCRIPTION
I am targeting this branch because it is a patch.

## Changelog

```markdown
### Added
- Added  `DoctrineCollector::clear` to clear properties of class.
```

## Subject

I am testing a set of bundles and libraries on a Mono repository. My suit test cases run all together and I create a kernel for every bundle. We use `DoctrineCollector`class to add some association and discriminators at runtime but all of them are propagated between kernels because DoctrineCollection uses the singleton pattern.

My PR try to find a solution for that issue. It is clear the properties of `DoctrineCollector` calling to `clear` method at the end of `AddMapperInformationCompilerPass::process` to avoid propagating the state of the class.