### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "doctrine/orm": "^2.2",
         "symfony/phpunit-bridge": "^3.3 || ^4.0"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0"
+        "symfony/phpunit-bridge": "^4.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,10 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/finder": "^2.8 || ^3.2 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0"
+        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
- Add composer sort packages
- Allow only 4.0 of phpunit-bridge
- Declare missing dependencies