### PR TITLE
Drop old versions of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/finder": "^2.8 || ^3.2 || ^4.0",


### PR DESCRIPTION
## Subject
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for php 5 and php 7.0
```
