### PR TITLE
Changed default namespace to App

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,10 @@
 UPGRADE 2.x
 ===========
 
+### Namespace
+
+The generated namespace was changed from `Application` to `App`.
+
 ### Deprecated
 
 Generated Bundles no longer use Bundle inheritance, because Symfony dropped the support for this in 3.4+ [symfony blog](https://symfony.com/blog/new-in-symfony-3-4-deprecated-bundle-inheritance)

--- a/docs/reference/introduction.rst
+++ b/docs/reference/introduction.rst
@@ -19,4 +19,4 @@ By default, this is set to ``app`` but you should probably set it to ``src``.
 
 You can optionally define a ``--namespace`` option to the command with the namespace for the extended bundle classes and directory structure.
 A special placeholder ``:vendor`` could be used and will be substitued with the bundle's `Vendor`.
-By default, this is set to ``Application\:vendor``.
+By default, this is set to ``App\:vendor``.

--- a/docs/reference/why.rst
+++ b/docs/reference/why.rst
@@ -67,7 +67,7 @@ A pragmatic way to solve this issue
 -----------------------------------
 
 The easiest way to solve this problem is to use global namespace inside your VB, the global namespace is the only
-namespace allowed  ``Application\YourBundle\Entity``.
+namespace allowed  ``App\Entity``.
 
 So, inside your mapping definition or inside your VB code, you will use one final namespace: ``problem solved``.
 How to achieve this:
@@ -75,11 +75,11 @@ How to achieve this:
 * Declare only SuperClass inside a VB, don’t use final entity,
 * Call your entity ``BaseXXXX`` and make it abstract, change the properties from private to protected,
 * The same goes for a repository,
-* Always use ``Application\YourBundle\Entity\XXXX`` inside your code.
+* Always use ``App\Entity\XXXX`` inside your code.
 
 Of course, you need to create for each VB bundle:
 
-* a valid structure inside the Application directory,
+* a valid structure inside the `App` directory,
 * a valid entity mapping definition,
 * a model inside the entity folder.
 
@@ -108,7 +108,7 @@ There are few options that you can add when executing command:
 * the ``--dest`` option allows you to choose the target directory, such
   as `src`. The default destination is the directory of your Kernel.
 * the ``--namespace`` option allows you to choose the base namespace, such
-  as `Application\\Sonata`. The default destination is `Application\\:vendor`.
+  as `App\\Sonata`. The default destination is `App\\:vendor`.
 * the ``--namespace_prefix`` option allows to provide a prefix for your namespace,
   this option is added because of the new directory structure that symfony-flex
   brings us. There is no Default value so if you are using flex you should

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -71,7 +71,7 @@ EOT
                 throw new \InvalidArgumentException('The provided namespace \'%s\' is not a valid namespace!', $namespace);
             }
         } else {
-            $namespace = 'Application\:vendor';
+            $namespace = 'App\:vendor';
         }
 
         $configuration = [

--- a/tests/Bundle/BundleMetadataTest.php
+++ b/tests/Bundle/BundleMetadataTest.php
@@ -31,8 +31,8 @@ class BundleMetadataTest extends TestCase
         $bundle = new \Sonata\AcmeBundle\SonataAcmeBundle();
 
         $bundleMetadata = new BundleMetadata($bundle, [
-            'application_dir' => 'app/Application/:vendor',
-            'namespace' => 'Application\\:vendor',
+            'application_dir' => 'app/App/:vendor',
+            'namespace' => 'App\\:vendor',
             'namespace_prefix' => '',
         ]);
 
@@ -41,8 +41,8 @@ class BundleMetadataTest extends TestCase
         $this->assertSame('SonataAcmeBundle', $bundleMetadata->getName());
         $this->assertSame('Sonata', $bundleMetadata->getVendor());
         $this->assertSame('Sonata\AcmeBundle', $bundleMetadata->getNamespace());
-        $this->assertSame('app/Application/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
-        $this->assertSame('Application\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
+        $this->assertSame('app/App/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
+        $this->assertSame('App\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
         $this->assertInstanceOf('Sonata\EasyExtendsBundle\Bundle\OrmMetadata', $bundleMetadata->getOrmMetadata());
         $this->assertInstanceOf('Sonata\EasyExtendsBundle\Bundle\OdmMetadata', $bundleMetadata->getOdmMetadata());
         $this->assertSame($bundle, $bundleMetadata->getBundle());
@@ -64,11 +64,11 @@ class BundleMetadataTest extends TestCase
 
     public function testApplicationNotExtendableBundle()
     {
-        $bundle = new \Application\Sonata\NotExtendableBundle();
+        $bundle = new \App\Sonata\NotExtendableBundle();
 
         $bundleMetadata = new BundleMetadata($bundle, [
-            'application_dir' => 'Application',
-            'namespace' => 'Application',
+            'application_dir' => 'App',
+            'namespace' => 'App',
             'namespace_prefix' => '',
         ]);
 
@@ -81,8 +81,8 @@ class BundleMetadataTest extends TestCase
         $bundle = new \Symfony\Bundle\NotExtendableBundle();
 
         $bundleMetadata = new BundleMetadata($bundle, [
-            'application_dir' => 'Application',
-            'namespace' => 'Application',
+            'application_dir' => 'App',
+            'namespace' => 'App',
             'namespace_prefix' => '',
         ]);
 
@@ -95,8 +95,8 @@ class BundleMetadataTest extends TestCase
         $bundle = new \Sonata\Bundle\AcmeBundle\LongNamespaceBundle();
 
         $bundleMetadata = new BundleMetadata($bundle, [
-            'application_dir' => 'Application',
-            'namespace' => 'Application',
+            'application_dir' => 'App',
+            'namespace' => 'App',
             'namespace_prefix' => '',
         ]);
 
@@ -108,8 +108,8 @@ class BundleMetadataTest extends TestCase
         $bundle = new \Sonata\AcmeBundle\AcmeBundle();
 
         $bundleMetadata = new BundleMetadata($bundle, [
-            'application_dir' => 'Application',
-            'namespace' => 'Application',
+            'application_dir' => 'App',
+            'namespace' => 'App',
             'namespace_prefix' => '',
         ]);
 
@@ -121,17 +121,17 @@ class BundleMetadataTest extends TestCase
         $bundle = new \Sonata\AcmeBundle\SonataAcmeBundle();
 
         $bundleMetadata = new BundleMetadata($bundle, [
-            'application_dir' => 'src/Application/:vendor',
-            'namespace' => 'Application\\:vendor',
-            'namespace_prefix' => 'App\\',
+            'application_dir' => 'src/App/:vendor',
+            'namespace' => 'App\\:vendor',
+            'namespace_prefix' => 'Acme\\',
         ]);
 
         $this->assertSame('SonataAcmeBundle', $bundleMetadata->getName());
         $this->assertSame('Sonata', $bundleMetadata->getVendor());
-        $this->assertSame('Application', $bundleMetadata->getApplication());
+        $this->assertSame('App', $bundleMetadata->getApplication());
         $this->assertSame('Sonata\AcmeBundle', $bundleMetadata->getNamespace());
-        $this->assertSame('src/Application/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
-        $this->assertSame('App\Application\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
+        $this->assertSame('src/App/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
+        $this->assertSame('Acme\App\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
         $this->assertSame($bundle, $bundleMetadata->getBundle());
     }
 }

--- a/tests/Bundle/Fixtures/bundle1/SonataNotExtendableBundle.php
+++ b/tests/Bundle/Fixtures/bundle1/SonataNotExtendableBundle.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Application\Sonata;
+namespace App\Sonata;
 
 class NotExtendableBundle extends \Symfony\Component\HttpKernel\Bundle\Bundle
 {

--- a/tests/Bundle/OdmMetadataTest.php
+++ b/tests/Bundle/OdmMetadataTest.php
@@ -54,7 +54,7 @@ class OdmMetadataTest extends TestCase
     public function testGetExtendedMappingDocumentDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Resources/config/doctrine/';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Resources/config/doctrine/';
 
         $odmMetadata = new OdmMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -78,7 +78,7 @@ class OdmMetadataTest extends TestCase
     public function testGetExtendedDocumentDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Document';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Document';
 
         $odmMetadata = new OdmMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -90,7 +90,7 @@ class OdmMetadataTest extends TestCase
     public function testGetExtendedSerializerDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Resources/config/serializer';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Resources/config/serializer';
 
         $ormMetadata = new OdmMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -184,7 +184,7 @@ class OdmMetadataTest extends TestCase
             ->will($this->returnValue('Sonata\\AcmeBundle\\SonataAcmeBundle'));
         $bundleMetadata->expects($this->any())
             ->method('getExtendedDirectory')
-            ->will($this->returnValue('Application/Sonata/AcmeBundle'));
+            ->will($this->returnValue('App/Sonata/AcmeBundle'));
 
         return $bundleMetadata;
     }

--- a/tests/Bundle/OrmMetadataTest.php
+++ b/tests/Bundle/OrmMetadataTest.php
@@ -56,7 +56,7 @@ class OrmMetadataTest extends TestCase
     public function testGetExtendedMappingEntityDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Resources/config/doctrine/';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Resources/config/doctrine/';
 
         $ormMetadata = new OrmMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -80,7 +80,7 @@ class OrmMetadataTest extends TestCase
     public function testGetExtendedEntityDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Entity';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Entity';
 
         $ormMetadata = new OrmMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -92,7 +92,7 @@ class OrmMetadataTest extends TestCase
     public function testGetExtendedSerializerDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Resources/config/serializer';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Resources/config/serializer';
 
         $ormMetadata = new OrmMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -186,7 +186,7 @@ class OrmMetadataTest extends TestCase
             ->will($this->returnValue('Sonata\\AcmeBundle\\SonataAcmeBundle'));
         $bundleMetadata->expects($this->any())
             ->method('getExtendedDirectory')
-            ->will($this->returnValue('Application/Sonata/AcmeBundle'));
+            ->will($this->returnValue('App/Sonata/AcmeBundle'));
 
         return $bundleMetadata;
     }

--- a/tests/Bundle/PhpcrMetadataTest.php
+++ b/tests/Bundle/PhpcrMetadataTest.php
@@ -54,7 +54,7 @@ class PhpcrMetadataTest extends TestCase
     public function testGetExtendedMappingDocumentDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Resources/config/doctrine/';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Resources/config/doctrine/';
 
         $odmMetadata = new PhpcrMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -78,7 +78,7 @@ class PhpcrMetadataTest extends TestCase
     public function testGetExtendedDocumentDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/PHPCR';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/PHPCR';
 
         $odmMetadata = new PhpcrMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -90,7 +90,7 @@ class PhpcrMetadataTest extends TestCase
     public function testGetExtendedSerializerDirectory()
     {
         $bundlePath = __DIR__.'/Fixtures/bundle1';
-        $expectedDirectory = 'Application/Sonata/AcmeBundle/Resources/config/serializer';
+        $expectedDirectory = 'App/Sonata/AcmeBundle/Resources/config/serializer';
 
         $odmMetadata = new PhpcrMetadata($this->getBundleMetadataMock($bundlePath));
 
@@ -184,7 +184,7 @@ class PhpcrMetadataTest extends TestCase
             ->will($this->returnValue('Sonata\\AcmeBundle\\SonataAcmeBundle'));
         $bundleMetadata->expects($this->any())
             ->method('getExtendedDirectory')
-            ->will($this->returnValue('Application/Sonata/AcmeBundle'));
+            ->will($this->returnValue('App/Sonata/AcmeBundle'));
 
         return $bundleMetadata;
     }

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -53,7 +53,7 @@ final class GenerateCommandTest extends TestCase
                 [
                     '--dest' => 'src',
                     'bundle' => ['SonataAcmeBundle'],
-                    '--namespace' => 'Application\\Sonata',
+                    '--namespace' => 'App\\Sonata',
                 ],
             ],
             [
@@ -67,7 +67,7 @@ final class GenerateCommandTest extends TestCase
                 [
                     '--dest' => 'src',
                     'bundle' => ['SonataAcmeBundle'],
-                    '--namespace' => 'Application\\Sonata',
+                    '--namespace' => 'App\\Sonata',
                     '--namespace_prefix' => 'App',
                 ],
             ],
@@ -136,7 +136,7 @@ final class GenerateCommandTest extends TestCase
     public function testInvalidFolderStructure()
     {
         $commandTester = $this->buildCommand(
-            $this->mockContainerWithKernel(new \Application\Sonata\NotExtendableBundle())
+            $this->mockContainerWithKernel(new \App\Sonata\NotExtendableBundle())
         );
 
         $commandTester->execute([
@@ -145,7 +145,7 @@ final class GenerateCommandTest extends TestCase
         ]);
 
         $this->assertContains(
-            sprintf('Application\Sonata\NotExtendableBundle : wrong directory structure'),
+            sprintf('App\Sonata\NotExtendableBundle : wrong directory structure'),
             $commandTester->getDisplay()
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

According to symfony, the application namespace should be `App`

Fixes #172

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch—>

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataEasyExtendsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed generated namespace to `App`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
