### PR TITLE
Commands as services

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,14 @@
 UPGRADE 2.x
 ===========
 
+## Deprecated commands that get the dependencies from the container
+
+Any command that extends `Sonata\CacheBundle\Command\DumpMappingCommand` or
+`Sonata\CacheBundle\Command\DumpMappingCommand` should all dependencies as a 
+constructor parameter.
+This should be done automatically in applications that have
+autowiring enabled for such commands.
+
 ### Deprecated
 
 Generated Bundles no longer use Bundle inheritance, because Symfony dropped the support for this in 3.4+ [symfony blog](https://symfony.com/blog/new-in-symfony-3-4-deprecated-bundle-inheritance)

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "doctrine/doctrine-bundle": "^1.10",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/finder": "^2.8 || ^3.2 || ^4.0",

--- a/src/Command/DumpMappingCommand.php
+++ b/src/Command/DumpMappingCommand.php
@@ -41,7 +41,7 @@ class DumpMappingCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $factory = $this->getContainer()->get('doctrine')->getManager($input->getArgument('manager'))->getMetadataFactory();
 
@@ -52,5 +52,7 @@ class DumpMappingCommand extends ContainerAwareCommand
 
         $output->writeln($exporter->exportClassMetadata($metadata));
         $output->writeln('Done!');
+
+        return 0;
     }
 }

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -53,7 +53,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $destOption = $input->getOption('dest');
         if ($destOption) {
@@ -117,6 +117,8 @@ EOT
         }
 
         $output->writeln('done!');
+
+        return 0;
     }
 
     /**

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -2,9 +2,18 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Sonata\EasyExtendsBundle\Command\DumpMappingCommand" class="Sonata\EasyExtendsBundle\Command\DumpMappingCommand" public="true">
+            <argument type="constant">null</argument>
+            <argument type="service" id="doctrine"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\EasyExtendsBundle\Command\GenerateCommand" class="Sonata\EasyExtendsBundle\Command\GenerateCommand" public="true">
+            <argument type="constant">null</argument>
+            <argument type="service" id="kernel"/>
+            <argument type="service" id="sonata.easy_extends.generator.bundle"/>
+            <argument type="service" id="sonata.easy_extends.generator.orm"/>
+            <argument type="service" id="sonata.easy_extends.generator.odm"/>
+            <argument type="service" id="sonata.easy_extends.generator.phpcr"/>
+            <argument type="service" id="sonata.easy_extends.generator.serializer"/>
             <tag name="console.command"/>
         </service>
     </services>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
I am targeting this branch, because this is BC.

Commands in this project still access services directly through the container.
This PR tries to get them with DI, and falls back on accessing them through an interface, while deprecating doing so.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataEasyExtendsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Commands return int values instead of boolean values

### Deprecated
- not providing dependencies to commands extending `Sonata\CacheBundle\Command\DumpMappingCommand`
- not providing dependencies to commands extending `Sonata\CacheBundle\Command\GenerateCommand`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
