### PR TITLE
📝 correcting the documentation for installing the bundle

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -21,5 +21,5 @@ in ``bundles.php`` file of your project::
 
     return [
         // ...
-        Sonata\EasyExtendsBundle\SonataEasyExtendsBundle::class => ['dev' => true],
+        Sonata\EasyExtendsBundle\SonataEasyExtendsBundle::class => ['all' => true],
     ];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
The installation documentation is wrong, when you follow it and put the dev to true, an error occurs when we go into production.
By putting all to true, at that moment, the error is no longer present.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #215 


