### PR TITLE
Fix PhpStorm findings

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+name: Quality assurance
+jobs:
+    phpstan:
+        name: PHPStan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: PHPStan
+              uses: "docker://oskarstark/phpstan-ga"
+              with:
+                  args: analyse

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
-        "symfony/phpunit-bridge": "^4.2"
+        "symfony/phpunit-bridge": "^5.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,12 @@
         "symfony/console": "^3.4 || ^4.2",
         "symfony/dependency-injection": "^3.4 || ^4.2",
         "symfony/finder": "^3.4 || ^4.2",
-        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "symfony/framework-bundle": "^3.4.23 || ^4.3",
         "symfony/http-kernel": "^3.4 || ^4.2"
     },
     "require-dev": {
-        "doctrine/orm": "^2.2",
+        "doctrine/doctrine-bundle": "^1.12",
+        "doctrine/orm": "^2.7",
         "symfony/phpunit-bridge": "^5.0"
     },
     "config": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: 4
+
+    paths:
+        - src

--- a/src/Command/DumpMappingCommand.php
+++ b/src/Command/DumpMappingCommand.php
@@ -34,8 +34,8 @@ class DumpMappingCommand extends ContainerAwareCommand
         $this->setName('sonata:easy-extends:dump-mapping');
         $this->setDescription('Dump some mapping information (debug only)');
 
-        $this->addArgument('manager', InputArgument::OPTIONAL, 'The manager name to use', false);
-        $this->addArgument('model', InputArgument::OPTIONAL, 'The class to dump', false);
+        $this->addArgument('manager', InputArgument::OPTIONAL, 'The manager name to use');
+        $this->addArgument('model', InputArgument::OPTIONAL, 'The class to dump');
     }
 
     /**

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -68,7 +68,10 @@ EOT
         $namespace = $input->getOption('namespace');
         if ($namespace) {
             if (!preg_match('/^(?:(?:[[:alnum:]]+|:vendor)\\\\?)+$/', $namespace)) {
-                throw new \InvalidArgumentException('The provided namespace \'%s\' is not a valid namespace!', $namespace);
+                throw new \InvalidArgumentException(sprintf(
+                    'The provided namespace "%s" is not a valid namespace!',
+                    $namespace
+                ));
             }
         } else {
             $namespace = 'Application\:vendor';

--- a/src/Generator/OdmGenerator.php
+++ b/src/Generator/OdmGenerator.php
@@ -119,7 +119,7 @@ class OdmGenerator implements GeneratorInterface
 
                 $string = Mustache::replace($this->getDocumentTemplate(), [
                     'extended_namespace' => $bundleMetadata->getExtendedNamespace(),
-                    'name' => $name !== $extendedName ? $extendedName : $name,
+                    'name' => $extendedName,
                     'class' => $name,
                     'extended_name' => $name === $extendedName ? 'Base'.$name : $extendedName,
                     'namespace' => $bundleMetadata->getNamespace(),

--- a/src/Generator/OrmGenerator.php
+++ b/src/Generator/OrmGenerator.php
@@ -102,7 +102,7 @@ class OrmGenerator implements GeneratorInterface
 
                 $string = Mustache::replace($this->getEntityTemplate(), [
                     'extended_namespace' => $bundleMetadata->getExtendedNamespace(),
-                    'name' => $name !== $extendedName ? $extendedName : $name,
+                    'name' => $extendedName,
                     'class' => $name,
                     'extended_name' => $name === $extendedName ? 'Base'.$name : $extendedName,
                     'namespace' => $bundleMetadata->getNamespace(),

--- a/src/Generator/PHPCRGenerator.php
+++ b/src/Generator/PHPCRGenerator.php
@@ -102,7 +102,7 @@ class PHPCRGenerator implements GeneratorInterface
 
                 $string = Mustache::replace($this->getDocumentTemplate(), [
                     'extended_namespace' => $bundleMetadata->getExtendedNamespace(),
-                    'name' => $name !== $extendedName ? $extendedName : $name,
+                    'name' => $extendedName,
                     'class' => $name,
                     'extended_name' => $name === $extendedName ? 'Base'.$name : $extendedName,
                     'namespace' => $bundleMetadata->getNamespace(),

--- a/src/Mapper/DoctrineORMMapper.php
+++ b/src/Mapper/DoctrineORMMapper.php
@@ -183,9 +183,6 @@ class DoctrineORMMapper implements EventSubscriber
         $this->overrides[$class][$type] = $options;
     }
 
-    /**
-     * @param $eventArgs
-     */
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
     {
         $metadata = $eventArgs->getClassMetadata();
@@ -217,7 +214,7 @@ class DoctrineORMMapper implements EventSubscriber
                         continue;
                     }
 
-                    \call_user_func([$metadata, $type], $mapping);
+                    $metadata->$type($mapping);
                 }
             }
         } catch (\ReflectionException $e) {
@@ -320,7 +317,7 @@ class DoctrineORMMapper implements EventSubscriber
         try {
             foreach ($this->overrides[$metadata->name] as $type => $overrides) {
                 foreach ($overrides as $override) {
-                    \call_user_func([$metadata, $type], $override['fieldName'], $override);
+                    $metadata->$type($override['fieldName'], $override);
                 }
             }
         } catch (\ReflectionException $e) {

--- a/tests/Bundle/BundleMetadataTest.php
+++ b/tests/Bundle/BundleMetadataTest.php
@@ -23,6 +23,8 @@ require_once __DIR__.'/Fixtures/bundle1/AcmeBundle.php';
 
 use PHPUnit\Framework\TestCase;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
+use Sonata\EasyExtendsBundle\Bundle\OdmMetadata;
+use Sonata\EasyExtendsBundle\Bundle\OrmMetadata;
 
 class BundleMetadataTest extends TestCase
 {
@@ -43,8 +45,8 @@ class BundleMetadataTest extends TestCase
         $this->assertSame('Sonata\AcmeBundle', $bundleMetadata->getNamespace());
         $this->assertSame('app/Application/Sonata/AcmeBundle', $bundleMetadata->getExtendedDirectory());
         $this->assertSame('Application\Sonata\AcmeBundle', $bundleMetadata->getExtendedNamespace());
-        $this->assertInstanceOf('Sonata\EasyExtendsBundle\Bundle\OrmMetadata', $bundleMetadata->getOrmMetadata());
-        $this->assertInstanceOf('Sonata\EasyExtendsBundle\Bundle\OdmMetadata', $bundleMetadata->getOdmMetadata());
+        $this->assertInstanceOf(OrmMetadata::class, $bundleMetadata->getOrmMetadata());
+        $this->assertInstanceOf(OdmMetadata::class, $bundleMetadata->getOdmMetadata());
         $this->assertSame($bundle, $bundleMetadata->getBundle());
     }
 

--- a/tests/Bundle/OdmMetadataTest.php
+++ b/tests/Bundle/OdmMetadataTest.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sonata\EasyExtendsBundle\Tests\Bundle;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AcmeBundle\SonataAcmeBundle;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 use Sonata\EasyExtendsBundle\Bundle\OdmMetadata;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class OdmMetadataTest extends TestCase
 {
@@ -111,7 +114,7 @@ class OdmMetadataTest extends TestCase
         }
 
         $this->assertInstanceOf('Iterator', $filterIterator);
-        $this->assertContainsOnly('Symfony\Component\Finder\SplFileInfo', $filterIterator);
+        $this->assertContainsOnly(SplFileInfo::class, $filterIterator);
         $this->assertContains('Block.mongodb.xml.skeleton', $files);
         $this->assertContains('Page.mongodb.xml.skeleton', $files);
         $this->assertNotContains('Block.odm.xml.skeleton', $files);
@@ -124,7 +127,7 @@ class OdmMetadataTest extends TestCase
 
         $result = $odmMetadata->getDocumentMappingFiles();
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
@@ -140,7 +143,7 @@ class OdmMetadataTest extends TestCase
         }
 
         $this->assertInstanceOf('Iterator', $filterIterator);
-        $this->assertContainsOnly('Symfony\Component\Finder\SplFileInfo', $filterIterator);
+        $this->assertContainsOnly(SplFileInfo::class, $filterIterator);
         $this->assertContains('BlockRepository.php', $files);
         $this->assertContains('PageRepository.php', $files);
         $this->assertNotContains('Block.php', $files);
@@ -153,7 +156,7 @@ class OdmMetadataTest extends TestCase
 
         $result = $odmMetadata->getRepositoryFiles();
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
@@ -164,25 +167,19 @@ class OdmMetadataTest extends TestCase
      */
     private function getBundleMetadataMock($bundlePath)
     {
-        $bundle = $this->createMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-        $bundle->expects($this->any())
+        $bundle = $this->createMock(Bundle::class);
+        $bundle
             ->method('getPath')
             ->willReturn($bundlePath);
 
-        $bundleMetadata = $this->createMock(
-            'Sonata\EasyExtendsBundle\Bundle\BundleMetadata',
-            [],
-            [$bundle],
-            '',
-            true
-        );
-        $bundleMetadata->expects($this->any())
+        $bundleMetadata = $this->createMock(BundleMetadata::class);
+        $bundleMetadata
             ->method('getBundle')
             ->willReturn($bundle);
-        $bundleMetadata->expects($this->any())
+        $bundleMetadata
             ->method('getClass')
-            ->willReturn('Sonata\\AcmeBundle\\SonataAcmeBundle');
-        $bundleMetadata->expects($this->any())
+            ->willReturn(SonataAcmeBundle::class);
+        $bundleMetadata
             ->method('getExtendedDirectory')
             ->willReturn('Application/Sonata/AcmeBundle');
 

--- a/tests/Bundle/OrmMetadataTest.php
+++ b/tests/Bundle/OrmMetadataTest.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sonata\EasyExtendsBundle\Tests\Bundle;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AcmeBundle\SonataAcmeBundle;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 use Sonata\EasyExtendsBundle\Bundle\OrmMetadata;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class OrmMetadataTest extends TestCase
 {
@@ -113,7 +116,7 @@ class OrmMetadataTest extends TestCase
         }
 
         $this->assertInstanceOf('Iterator', $filterIterator);
-        $this->assertContainsOnly('Symfony\Component\Finder\SplFileInfo', $filterIterator);
+        $this->assertContainsOnly(SplFileInfo::class, $filterIterator);
         $this->assertContains('Block.orm.xml.skeleton', $files);
         $this->assertContains('Page.orm.xml.skeleton', $files);
         $this->assertNotContains('Block.mongodb.xml.skeleton', $files);
@@ -126,7 +129,7 @@ class OrmMetadataTest extends TestCase
 
         $result = $ormMetadata->getEntityMappingFiles();
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
@@ -142,7 +145,7 @@ class OrmMetadataTest extends TestCase
         }
 
         $this->assertInstanceOf('Iterator', $filterIterator);
-        $this->assertContainsOnly('Symfony\Component\Finder\SplFileInfo', $filterIterator);
+        $this->assertContainsOnly(SplFileInfo::class, $filterIterator);
         $this->assertContains('BlockRepository.php', $files);
         $this->assertContains('PageRepository.php', $files);
         $this->assertNotContains('Block.php', $files);
@@ -155,7 +158,7 @@ class OrmMetadataTest extends TestCase
 
         $result = $ormMetadata->getRepositoryFiles();
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
@@ -166,25 +169,19 @@ class OrmMetadataTest extends TestCase
      */
     private function getBundleMetadataMock($bundlePath)
     {
-        $bundle = $this->createMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-        $bundle->expects($this->any())
+        $bundle = $this->createMock(Bundle::class);
+        $bundle
             ->method('getPath')
             ->willReturn($bundlePath);
 
-        $bundleMetadata = $this->createMock(
-            'Sonata\EasyExtendsBundle\Bundle\BundleMetadata',
-            [],
-            [$bundle],
-            '',
-            true
-        );
-        $bundleMetadata->expects($this->any())
+        $bundleMetadata = $this->createMock(BundleMetadata::class);
+        $bundleMetadata
             ->method('getBundle')
             ->willReturn($bundle);
-        $bundleMetadata->expects($this->any())
+        $bundleMetadata
             ->method('getClass')
-            ->willReturn('Sonata\\AcmeBundle\\SonataAcmeBundle');
-        $bundleMetadata->expects($this->any())
+            ->willReturn(SonataAcmeBundle::class);
+        $bundleMetadata
             ->method('getExtendedDirectory')
             ->willReturn('Application/Sonata/AcmeBundle');
 

--- a/tests/Bundle/PhpcrMetadataTest.php
+++ b/tests/Bundle/PhpcrMetadataTest.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sonata\EasyExtendsBundle\Tests\Bundle;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AcmeBundle\SonataAcmeBundle;
 use Sonata\EasyExtendsBundle\Bundle\BundleMetadata;
 use Sonata\EasyExtendsBundle\Bundle\PhpcrMetadata;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PhpcrMetadataTest extends TestCase
 {
@@ -111,7 +114,7 @@ class PhpcrMetadataTest extends TestCase
         }
 
         $this->assertInstanceOf('Iterator', $filterIterator);
-        $this->assertContainsOnly('Symfony\Component\Finder\SplFileInfo', $filterIterator);
+        $this->assertContainsOnly(SplFileInfo::class, $filterIterator);
         $this->assertContains('Block.phpcr.xml.skeleton', $files);
         $this->assertContains('Page.phpcr.xml.skeleton', $files);
         $this->assertNotContains('Block.odm.xml.skeleton', $files);
@@ -124,7 +127,7 @@ class PhpcrMetadataTest extends TestCase
 
         $result = $odmMetadata->getDocumentMappingFiles();
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
@@ -140,7 +143,7 @@ class PhpcrMetadataTest extends TestCase
         }
 
         $this->assertInstanceOf('Iterator', $filterIterator);
-        $this->assertContainsOnly('Symfony\Component\Finder\SplFileInfo', $filterIterator);
+        $this->assertContainsOnly(SplFileInfo::class, $filterIterator);
         $this->assertContains('BlockRepository.php', $files);
         $this->assertContains('PageRepository.php', $files);
         $this->assertNotContains('Block.php', $files);
@@ -153,7 +156,7 @@ class PhpcrMetadataTest extends TestCase
 
         $result = $odmMetadata->getRepositoryFiles();
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
@@ -164,25 +167,19 @@ class PhpcrMetadataTest extends TestCase
      */
     private function getBundleMetadataMock($bundlePath)
     {
-        $bundle = $this->createMock('Symfony\Component\HttpKernel\Bundle\Bundle');
-        $bundle->expects($this->any())
+        $bundle = $this->createMock(Bundle::class);
+        $bundle
             ->method('getPath')
             ->willReturn($bundlePath);
 
-        $bundleMetadata = $this->createMock(
-            'Sonata\EasyExtendsBundle\Bundle\BundleMetadata',
-            [],
-            [$bundle],
-            '',
-            true
-        );
-        $bundleMetadata->expects($this->any())
+        $bundleMetadata = $this->createMock(BundleMetadata::class);
+        $bundleMetadata
             ->method('getBundle')
             ->willReturn($bundle);
-        $bundleMetadata->expects($this->any())
+        $bundleMetadata
             ->method('getClass')
-            ->willReturn('Sonata\\AcmeBundle\\SonataAcmeBundle');
-        $bundleMetadata->expects($this->any())
+            ->willReturn(SonataAcmeBundle::class);
+        $bundleMetadata
             ->method('getExtendedDirectory')
             ->willReturn('Application/Sonata/AcmeBundle');
 

--- a/tests/Command/Functional/AppKernel.php
+++ b/tests/Command/Functional/AppKernel.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EasyExtendsBundle\Tests\Command\Functional;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Sonata\EasyExtendsBundle\SonataEasyExtendsBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+final class AppKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', false);
+    }
+
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineBundle(),
+            new SonataEasyExtendsBundle(),
+        ];
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->getBaseDir().'cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->getBaseDir().'log';
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+    }
+
+    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
+    {
+        $containerBuilder->loadFromExtension('framework', [
+            'secret' => 'MySecret',
+        ]);
+
+        $containerBuilder->loadFromExtension('doctrine', [
+            'orm' => [
+                'entity_managers' => [
+                    'default' => [
+                        'auto_mapping' => true,
+                        'mappings' => [
+                            'App' => [
+                                'type' => 'annotation',
+                                'dir' => '%kernel.project_dir%/Entity',
+                                'is_bundle' => false,
+                                'prefix' => 'Sonata\EasyExtendsBundle\Tests\Command\Functional\Entity',
+                                'alias' => 'SonataFunctional',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'dbal' => [
+                'driver' => 'pdo_sqlite',
+            ],
+        ]);
+    }
+
+    private function getBaseDir(): string
+    {
+        return sys_get_temp_dir().'/sonata-easy-extends-bundle/var/';
+    }
+}

--- a/tests/Command/Functional/DumpMappingCommandTest.php
+++ b/tests/Command/Functional/DumpMappingCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EasyExtendsBundle\Tests\Command\Functional;
+
+use Sonata\EasyExtendsBundle\Tests\Command\Functional\Entity\Block;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DumpMappingCommandTest extends KernelTestCase
+{
+    public function testExecute(): void
+    {
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+        $command = $application->find('sonata:easy-extends:dump-mapping');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'manager' => 'default',
+            'model' => Block::class,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('<?php', $output);
+        $this->assertStringContainsString('Block', $output);
+    }
+
+    protected static function getKernelClass()
+    {
+        return AppKernel::class;
+    }
+}

--- a/tests/Command/Functional/Entity/Block.php
+++ b/tests/Command/Functional/Entity/Block.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EasyExtendsBundle\Tests\Command\Functional\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Block
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+}

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -34,7 +34,7 @@ final class GenerateCommandTest extends TestCase
         $commandTester = $this->buildCommand($this->mockContainer());
         $commandTester->execute($args);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'done!',
             $commandTester->getDisplay()
         );
@@ -94,7 +94,7 @@ final class GenerateCommandTest extends TestCase
             '--dest' => 'src',
         ]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You must provide a bundle name!',
             $commandTester->getDisplay()
         );
@@ -112,7 +112,7 @@ final class GenerateCommandTest extends TestCase
             'bundle' => ['FakeBundle'],
         ]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You must provide a bundle name!',
             $commandTester->getDisplay()
         );
@@ -127,7 +127,7 @@ final class GenerateCommandTest extends TestCase
             'bundle' => ['NotExtendableBundle'],
         ]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             sprintf('Ignoring bundle : "Symfony\Bundle\NotExtendableBundle"'),
             $commandTester->getDisplay()
         );
@@ -144,7 +144,7 @@ final class GenerateCommandTest extends TestCase
             'bundle' => ['NotExtendableBundle'],
         ]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             sprintf('Application\Sonata\NotExtendableBundle : wrong directory structure'),
             $commandTester->getDisplay()
         );

--- a/tests/Mapper/DoctrineORMMapperTest.php
+++ b/tests/Mapper/DoctrineORMMapperTest.php
@@ -30,10 +30,10 @@ class DoctrineORMMapperTest extends TestCase
      */
     private $metadata;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->doctrine = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry', [], [], '', false);
-        $this->metadata = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo', [], [], '', false);
+        $this->doctrine = $this->createMock(ManagerRegistry::class);
+        $this->metadata = $this->createMock(ClassMetadataInfo::class);
     }
 
     public function testLoadDiscriminators()


### PR DESCRIPTION
Not sure if this should be in the changelog. My plan after this was to do this in master branch:
- Fix Command deprecations (extending from `ContainerAwareCommand`) 
- Changing classes to final, add types, etc
- Add support for Symfony 5 (and dropping 3.4?)